### PR TITLE
ci: pin pnpm to v9 so build scripts run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: latest
+        version: 9
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The Pages deploy failed at `pnpm install`: pnpm 10 (installed by `version: latest`) blocks dependency build scripts by default, so esbuild's postinstall was skipped and the step exited with `ERR_PNPM_IGNORED_BUILDS`.

Pin both CI and the deploy workflow to **pnpm 9**, which matches the committed lockfile and runs esbuild's binary setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)