### PR TITLE
feat: add vocabulary table with click-to-read lookup

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -12,6 +12,12 @@ library, with two parts:
   analyzer and see its grammatical structure. All 380+ snippets are verified to
   type-check **and** resolve to exactly the sentence shown
   (`pnpm verify:snippets`).
+- **📚 Glossary** — a searchable vocabulary table (`src/vocab`) of every word
+  the course uses: kanji, kana reading, romaji, part of speech, and bilingual
+  meaning. In the course, each example shows its words as clickable chips —
+  click any word to see how it's read and what it means; the structure tree
+  shows furigana inline too. A compiler check (`pnpm verify:vocab`) guarantees
+  **every** word used in the course is indexed in the table.
 - **🧪 Playground** — write a Japanese sentence as a TypeScript type and watch
   how it's composed, node by node.
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "verify:snippets": "node scripts/verify-snippets.mjs"
+    "verify:snippets": "node scripts/verify-snippets.mjs",
+    "verify:vocab": "node scripts/verify-vocab.mjs"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",

--- a/playground/scripts/extract-words.mjs
+++ b/playground/scripts/extract-words.mjs
@@ -1,0 +1,125 @@
+/**
+ * Extract every content word the tutorial uses, by parsing each example's
+ * Typed Japanese snippet with the TypeScript Compiler API. These are the words
+ * the vocabulary table must cover.
+ *
+ *   node scripts/extract-words.mjs           # summary
+ *   node scripts/extract-words.mjs --json    # { words: [{word,pos}], literals: [...] }
+ *
+ * "Words" = nouns (ProperNoun<"…">), verbs (Godan/Ichidan/Irregular) and
+ * adjectives (I/Na) declared through the library's typed constructors. We also
+ * collect the raw string literals used as glue, minus known grammar particles,
+ * as adverb/expression candidates.
+ */
+import ts from "typescript";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLAYGROUND = path.resolve(__dirname, "..");
+const CHAPTERS_DIR = path.join(PLAYGROUND, "src/tutorial/chapters");
+
+const GRAMMAR_LITERALS = new Set([
+  // particles
+  "は","が","を","に","へ","で","と","から","まで","よ","ね","か","よね","の","だ","も",
+  // copula / suffixes / endings commonly glued in templates
+  "です","でした","ではありません","ですか","ます","ました","ません","ませんでした",
+  "ない","なかった","た","て","だ","である","う","る","ば","なら","たら","れば",
+  "、","。","！","？","「","」",
+]);
+
+function loadChapter(file) {
+  const src = fs.readFileSync(file, "utf8");
+  const js = ts.transpileModule(src, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const mod = { exports: {} };
+  new Function("module", "exports", "require", js)(mod, mod.exports, () => ({}));
+  return mod.exports.default;
+}
+
+const words = new Map(); // word -> Set(pos)
+const literals = new Map(); // literal -> count
+function addWord(w, pos) {
+  if (!w) return;
+  if (!words.has(w)) words.set(w, new Set());
+  words.get(w).add(pos);
+}
+
+function objMembers(typeLiteral) {
+  const out = {};
+  for (const m of typeLiteral.members || []) {
+    if (ts.isPropertySignature(m) && m.name && m.type && ts.isLiteralTypeNode(m.type) && ts.isStringLiteral(m.type.literal)) {
+      out[m.name.getText()] = m.type.literal.text;
+    }
+  }
+  return out;
+}
+
+function walk(node, sf) {
+  // ProperNoun<"X">
+  if (ts.isTypeReferenceNode(node) && node.typeName.getText() === "ProperNoun" && node.typeArguments?.[0]) {
+    const a = node.typeArguments[0];
+    if (ts.isLiteralTypeNode(a) && ts.isStringLiteral(a.literal)) addWord(a.literal.text, "noun");
+  }
+  // Verb / adjective intersections: <Ctor> & { ... }
+  if (ts.isIntersectionTypeNode(node)) {
+    const ref = node.types.find((t) => ts.isTypeReferenceNode(t));
+    const lit = node.types.find((t) => ts.isTypeLiteralNode(t));
+    if (ref) {
+      const ctor = ref.typeName.getText();
+      const props = lit ? objMembers(lit) : {};
+      if (ctor === "GodanVerb" && props.stem && props.ending) addWord(props.stem + props.ending, "verb-godan");
+      else if (ctor === "IchidanVerb" && props.stem) addWord(props.stem + (props.ending || "る"), "verb-ichidan");
+      else if (ctor === "IAdjective" && props.stem) addWord(props.stem + (props.ending || "い"), "i-adjective");
+      else if (ctor === "NaAdjective" && props.stem) addWord(props.stem, "na-adjective");
+    }
+  }
+  // IrregularVerb & { dictionary: "..." }
+  if (ts.isIntersectionTypeNode(node)) {
+    const ref = node.types.find((t) => ts.isTypeReferenceNode(t) && t.typeName.getText() === "IrregularVerb");
+    const lit = node.types.find((t) => ts.isTypeLiteralNode(t));
+    if (ref && lit) {
+      const props = objMembers(lit);
+      if (props.dictionary) addWord(props.dictionary, "verb-irregular");
+    }
+  }
+  // raw string literals (candidates)
+  if (ts.isLiteralTypeNode(node) && ts.isStringLiteral(node.literal)) {
+    const v = node.literal.text;
+    if (v && !GRAMMAR_LITERALS.has(v)) literals.set(v, (literals.get(v) || 0) + 1);
+  }
+  ts.forEachChild(node, (c) => walk(c, sf));
+}
+
+const files = fs.readdirSync(CHAPTERS_DIR).filter((f) => f.endsWith(".ts") && f !== "index.ts");
+for (const f of files) {
+  let chapter;
+  try { chapter = loadChapter(path.join(CHAPTERS_DIR, f)); } catch { continue; }
+  if (!chapter?.points) continue;
+  for (const pt of chapter.points)
+    for (const ex of pt.examples || []) {
+      const sf = ts.createSourceFile("x.ts", ex.code || "", ts.ScriptTarget.Latest, true);
+      walk(sf, sf);
+    }
+}
+
+const wordList = [...words.entries()]
+  .map(([word, set]) => ({ word, pos: [...set][0] }))
+  .sort((a, b) => a.word.localeCompare(b.word, "ja"));
+const litList = [...literals.entries()]
+  .filter(([v]) => !/^[ぁ-ん]{1,2}$/.test(v)) // drop tiny kana glue
+  .map(([word, count]) => ({ word, count }))
+  .sort((a, b) => b.count - a.count);
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify({ words: wordList, literals: litList }, null, 2));
+} else {
+  console.log(`Words (typed constructors): ${wordList.length}`);
+  const byPos = {};
+  for (const w of wordList) byPos[w.pos] = (byPos[w.pos] || 0) + 1;
+  console.log(byPos);
+  console.log(`\nLiteral candidates (non-grammar): ${litList.length}`);
+  console.log(litList.slice(0, 40).map((l) => l.word).join("  "));
+}

--- a/playground/scripts/verify-vocab.mjs
+++ b/playground/scripts/verify-vocab.mjs
@@ -1,0 +1,67 @@
+/**
+ * Guarantee that every content word used in the tutorial's Typed Japanese
+ * snippets indexes into the maintained vocabulary table. This is the compiler-
+ * checked link between the course and src/vocab.
+ *
+ *   node scripts/verify-vocab.mjs            # summary, exits non-zero on gaps
+ *   node scripts/verify-vocab.mjs --json     # { missing: [...] }
+ *
+ * Words come from scripts/extract-words.mjs (parsed via the TS compiler). The
+ * vocabulary keys come from src/vocab/function-words.ts + src/vocab/entries/*.ts.
+ */
+import ts from "typescript";
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLAYGROUND = path.resolve(__dirname, "..");
+const VOCAB_DIR = path.join(PLAYGROUND, "src/vocab");
+
+function evalModule(file) {
+  const src = fs.readFileSync(file, "utf8");
+  const js = ts.transpileModule(src, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const mod = { exports: {} };
+  new Function("module", "exports", "require", js)(mod, mod.exports, () => ({}));
+  return mod.exports;
+}
+
+// --- collect vocabulary keys ---
+const keys = new Set();
+const addEntries = (arr) => {
+  for (const e of arr || []) if (e?.word) keys.add(e.word);
+};
+addEntries(evalModule(path.join(VOCAB_DIR, "function-words.ts")).FUNCTION_WORDS);
+
+const entriesDir = path.join(VOCAB_DIR, "entries");
+if (fs.existsSync(entriesDir)) {
+  for (const f of fs.readdirSync(entriesDir).filter((f) => f.endsWith(".ts"))) {
+    const mod = evalModule(path.join(entriesDir, f));
+    addEntries(mod.default || mod.entries);
+  }
+}
+
+// --- collect required words ---
+const extracted = JSON.parse(
+  execSync(`node ${path.join(__dirname, "extract-words.mjs")} --json`, { encoding: "utf8" })
+);
+const required = extracted.words; // [{ word, pos }]
+
+const missing = required.filter((w) => !keys.has(w.word));
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify({ totalRequired: required.length, vocabKeys: keys.size, missing }, null, 2));
+} else {
+  console.log(`Vocabulary keys: ${keys.size} | words used by course: ${required.length}`);
+  if (missing.length === 0) {
+    console.log("✓ Every course word is indexed in the vocabulary table.");
+  } else {
+    console.log(`✗ ${missing.length} word(s) missing from the table:\n`);
+    for (const m of missing) console.log(`  ${m.word}  (${m.pos})`);
+  }
+}
+
+process.exit(missing.length === 0 ? 0 : 1);

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import Tutorial from "./components/Tutorial";
 import Playground from "./components/Playground";
+import Glossary from "./components/Glossary";
 import { useLang } from "./context/lang";
 import styles from "./App.module.css";
 
-type Tab = "tutorial" | "playground";
+type Tab = "tutorial" | "glossary" | "playground";
 
 export default function App() {
   const { lang, setLang, t } = useLang();
@@ -60,6 +61,12 @@ export default function App() {
           📖 {t("Grammar Course", "语法教程")}
         </button>
         <button
+          className={`${styles.tab} ${tab === "glossary" ? styles.tabActive : ""}`}
+          onClick={() => setTab("glossary")}
+        >
+          📚 {t("Glossary", "词汇表")}
+        </button>
+        <button
           className={`${styles.tab} ${tab === "playground" ? styles.tabActive : ""}`}
           onClick={() => setTab("playground")}
         >
@@ -68,7 +75,9 @@ export default function App() {
       </nav>
 
       <main className={styles.main}>
-        {tab === "tutorial" ? <Tutorial /> : <Playground />}
+        {tab === "tutorial" && <Tutorial />}
+        {tab === "glossary" && <Glossary />}
+        {tab === "playground" && <Playground />}
       </main>
 
       <footer className={styles.footer}>

--- a/playground/src/components/CompositionTree.module.css
+++ b/playground/src/components/CompositionTree.module.css
@@ -44,6 +44,12 @@
   white-space: nowrap;
 }
 
+.reading {
+  font-size: 0.74rem;
+  color: var(--ink-500);
+  white-space: nowrap;
+}
+
 .ctor {
   font-family: var(--font-mono);
   font-size: 0.74rem;

--- a/playground/src/components/CompositionTree.tsx
+++ b/playground/src/components/CompositionTree.tsx
@@ -1,4 +1,6 @@
 import type { CompositionNode, GrammarCategory } from "../analysis/parse";
+import { lookup } from "../vocab/dictionary";
+import { useLang } from "../context/lang";
 import styles from "./CompositionTree.module.css";
 
 export const CATEGORY_META: Record<
@@ -31,6 +33,7 @@ export default function CompositionTree({
   onSelect,
   depth = 0,
 }: Props) {
+  const { lang } = useLang();
   const meta = CATEGORY_META[node.category];
   const color = `var(${meta.varName})`;
   const isLiteral = node.ctor === null && node.children.length === 0;
@@ -41,18 +44,23 @@ export default function CompositionTree({
   const showResolved =
     node.resolved != null && node.resolved !== "" && node.resolved !== literalValue;
 
+  // Look the word up in the vocabulary table to show its reading + meaning.
+  const lookupKey = node.label.replace(/^"|"$/g, "");
+  const entry = lookup(lookupKey);
+
   return (
     <div className={styles.node} style={{ ["--cat" as string]: color }}>
       <button
         type="button"
         className={`${styles.row} ${selected ? styles.selected : ""}`}
         onClick={() => onSelect(node)}
-        title={node.text}
+        title={entry ? `${entry.reading} · ${lang === "zh" ? entry.zh : entry.en}` : node.text}
       >
         <span className={styles.tag} style={{ background: color }}>
           {meta.jp}
         </span>
         <span className={`jp ${styles.label}`}>{node.label}</span>
+        {entry && <span className={`jp ${styles.reading}`}>{entry.reading}</span>}
         {node.ctor && <span className={styles.ctor}>{node.ctor}</span>}
         {showResolved && (
           <span className={`jp ${styles.resolved}`}>

--- a/playground/src/components/Glossary.module.css
+++ b/playground/src/components/Glossary.module.css
@@ -1,0 +1,103 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.search {
+  flex: 1;
+  min-width: 240px;
+}
+
+.filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filter {
+  cursor: pointer;
+  border: 1px solid var(--border);
+}
+
+.filterActive {
+  background: var(--sakura-500);
+  color: #fff;
+  border-color: var(--sakura-500);
+}
+
+.tableWrap {
+  overflow: auto;
+  max-height: calc(100vh - 260px);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--surface-2);
+  text-align: left;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-500);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table td {
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.table tbody tr:hover {
+  background: var(--surface-2);
+}
+
+.word {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ink-900);
+  white-space: nowrap;
+}
+
+.reading {
+  color: var(--sakura-600);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.romaji {
+  font-style: italic;
+  color: var(--ink-500);
+  white-space: nowrap;
+}
+
+.posTag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--sakura-600);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.meaning {
+  color: var(--ink-700);
+}

--- a/playground/src/components/Glossary.tsx
+++ b/playground/src/components/Glossary.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from "react";
+import { VOCAB_LIST } from "../vocab/dictionary";
+import { POS_LABEL, type PartOfSpeech } from "../vocab/types";
+import { useLang } from "../context/lang";
+import styles from "./Glossary.module.css";
+
+const POS_GROUPS: { key: PartOfSpeech[]; en: string; zh: string }[] = [
+  { key: ["noun", "pronoun"], en: "Nouns", zh: "名词" },
+  { key: ["verb-godan", "verb-ichidan", "verb-irregular"], en: "Verbs", zh: "动词" },
+  { key: ["i-adjective", "na-adjective"], en: "Adjectives", zh: "形容词" },
+  { key: ["adverb"], en: "Adverbs", zh: "副词" },
+  { key: ["particle", "copula", "suffix", "conjunction", "prefix"], en: "Grammar", zh: "语法词" },
+];
+
+export default function Glossary() {
+  const { lang, t } = useLang();
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<number | null>(null);
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const allowed = filter === null ? null : new Set(POS_GROUPS[filter]!.key);
+    return VOCAB_LIST.filter((e) => {
+      if (allowed && !allowed.has(e.pos)) return false;
+      if (!q) return true;
+      return (
+        e.word.toLowerCase().includes(q) ||
+        e.reading.includes(q) ||
+        e.romaji.toLowerCase().includes(q) ||
+        e.en.toLowerCase().includes(q) ||
+        e.zh.includes(q)
+      );
+    });
+  }, [query, filter]);
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.toolbar}>
+        <input
+          className={`tj-input ${styles.search}`}
+          placeholder={t("Search word, reading, romaji or meaning…", "搜索词语、读音、罗马字或释义…")}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <div className={styles.filters}>
+          <button
+            className={`tj-chip ${styles.filter} ${filter === null ? styles.filterActive : ""}`}
+            onClick={() => setFilter(null)}
+          >
+            {t("All", "全部")}
+          </button>
+          {POS_GROUPS.map((g, i) => (
+            <button
+              key={i}
+              className={`tj-chip ${styles.filter} ${filter === i ? styles.filterActive : ""}`}
+              onClick={() => setFilter(i)}
+            >
+              {t(g.en, g.zh)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p className="tj-subtle">
+        {t(
+          `${rows.length} of ${VOCAB_LIST.length} words`,
+          `${rows.length} / ${VOCAB_LIST.length} 个词`
+        )}
+      </p>
+
+      <div className={`tj-card ${styles.tableWrap}`}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>{t("Word", "词语")}</th>
+              <th>{t("Reading", "读音")}</th>
+              <th>{t("Romaji", "罗马字")}</th>
+              <th>{t("Type", "词性")}</th>
+              <th>{t("Meaning", "释义")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((e, i) => (
+              <tr key={`${e.word}-${i}`}>
+                <td className={`jp ${styles.word}`}>{e.word}</td>
+                <td className={`jp ${styles.reading}`}>{e.reading}</td>
+                <td className={styles.romaji}>{e.romaji}</td>
+                <td>
+                  <span className={styles.posTag}>{t(POS_LABEL[e.pos].en, POS_LABEL[e.pos].zh)}</span>
+                </td>
+                <td className={styles.meaning}>{lang === "zh" ? e.zh : e.en}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/Tutorial.module.css
+++ b/playground/src/components/Tutorial.module.css
@@ -189,6 +189,26 @@
   padding: 5px 12px;
 }
 
+.vocabRow {
+  flex-basis: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--border);
+}
+
+.vocabLabel {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-300);
+  margin-right: 2px;
+}
+
 /* ---- drawer ---- */
 .scrim {
   position: fixed;

--- a/playground/src/components/Tutorial.tsx
+++ b/playground/src/components/Tutorial.tsx
@@ -3,7 +3,9 @@ import { CHAPTERS } from "../tutorial/chapters";
 import { LEVEL_META } from "../tutorial/levels";
 import type { Chapter, Example, Level } from "../tutorial/types";
 import { useLang } from "../context/lang";
+import { extractWords } from "../vocab/extract";
 import Analyzer from "./Analyzer";
+import VocabWord from "./VocabWord";
 import styles from "./Tutorial.module.css";
 
 const LEVELS: Level[] = ["elementary", "intermediate", "advanced"];
@@ -146,6 +148,12 @@ export default function Tutorial() {
                       >
                         🔬 {t("Analyze", "解析")}
                       </button>
+                      <div className={styles.vocabRow}>
+                        <span className={styles.vocabLabel}>{t("Words", "词汇")}</span>
+                        {extractWords(ex.code).map((w, k) => (
+                          <VocabWord key={k} word={w.word} />
+                        ))}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/playground/src/components/VocabWord.module.css
+++ b/playground/src/components/VocabWord.module.css
@@ -1,0 +1,120 @@
+.chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
+  line-height: 1.15;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.chip:hover {
+  border-color: var(--sakura-400);
+  background: var(--surface-2);
+}
+
+.chipPlain {
+  color: var(--ink-500);
+}
+
+.inline {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  border-bottom: 1px dotted var(--border-strong);
+}
+
+.inline:hover {
+  color: var(--sakura-600);
+  border-color: var(--sakura-400);
+}
+
+.word {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.reading {
+  font-size: 0.68rem;
+  color: var(--ink-500);
+}
+
+/* popover */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+
+.popover {
+  position: fixed;
+  z-index: 61;
+  min-width: 200px;
+  max-width: 280px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  padding: 12px 14px;
+}
+
+.popHead {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.popWord {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: var(--ink-900);
+}
+
+.popReading {
+  font-size: 0.95rem;
+  color: var(--sakura-600);
+  font-weight: 700;
+}
+
+.popMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 8px;
+}
+
+.romaji {
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--ink-500);
+}
+
+.posTag {
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--sakura-600);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 1px 7px;
+  border-radius: 999px;
+}
+
+.meaning {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--ink-900);
+}
+
+.meaningAlt {
+  margin: 3px 0 0;
+  font-size: 0.82rem;
+  color: var(--ink-500);
+}

--- a/playground/src/components/VocabWord.tsx
+++ b/playground/src/components/VocabWord.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { lookup } from "../vocab/dictionary";
+import { POS_LABEL } from "../vocab/types";
+import { useLang } from "../context/lang";
+import styles from "./VocabWord.module.css";
+
+type Variant = "chip" | "plain";
+
+interface Props {
+  word: string;
+  /** override the displayed surface (e.g. an inflected form); lookup still uses `word` */
+  display?: string;
+  variant?: Variant;
+}
+
+export default function VocabWord({ word, display, variant = "chip" }: Props) {
+  const { lang, t } = useLang();
+  const entry = lookup(word);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("resize", close);
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("resize", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const label = display ?? word;
+  if (!entry) {
+    // No dictionary entry — render as inert text.
+    return <span className={variant === "chip" ? styles.chipPlain : ""}>{label}</span>;
+  }
+
+  const toggle = () => {
+    const r = ref.current?.getBoundingClientRect();
+    if (r) setPos({ top: r.bottom + 6, left: r.left });
+    setOpen((o) => !o);
+  };
+
+  return (
+    <>
+      <button
+        ref={ref}
+        type="button"
+        className={variant === "chip" ? styles.chip : styles.inline}
+        onClick={toggle}
+        aria-expanded={open}
+      >
+        <span className={`jp ${styles.word}`}>{label}</span>
+        {variant === "chip" && <span className={`jp ${styles.reading}`}>{entry.reading}</span>}
+      </button>
+
+      {open &&
+        pos &&
+        createPortal(
+          <>
+            <div className={styles.backdrop} onClick={() => setOpen(false)} />
+            <div className={styles.popover} style={{ top: pos.top, left: pos.left }}>
+              <div className={styles.popHead}>
+                <span className={`jp ${styles.popWord}`}>{entry.word}</span>
+                <span className={`jp ${styles.popReading}`}>{entry.reading}</span>
+              </div>
+              <div className={styles.popMeta}>
+                <span className={styles.romaji}>{entry.romaji}</span>
+                <span className={styles.posTag}>{t(POS_LABEL[entry.pos].en, POS_LABEL[entry.pos].zh)}</span>
+              </div>
+              <p className={styles.meaning}>{lang === "zh" ? entry.zh : entry.en}</p>
+              <p className={styles.meaningAlt}>{lang === "zh" ? entry.en : entry.zh}</p>
+            </div>
+          </>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/playground/src/vocab/dictionary.ts
+++ b/playground/src/vocab/dictionary.ts
@@ -1,0 +1,29 @@
+import type { VocabEntry } from "./types";
+import { FUNCTION_WORDS } from "./function-words";
+
+/**
+ * The merged vocabulary table: hand-maintained grammar words plus all content
+ * words authored under entries/. Keyed by headword. The compiler check in
+ * scripts/verify-vocab.mjs guarantees every word the course uses is present.
+ */
+const entryModules = import.meta.glob<{ default: VocabEntry[] }>("./entries/*.ts", {
+  eager: true,
+});
+
+const authored: VocabEntry[] = Object.values(entryModules).flatMap(
+  (m) => m.default ?? []
+);
+
+export const VOCAB = new Map<string, VocabEntry>();
+// Authored content words first; function words fill any gaps without overriding.
+for (const entry of [...authored, ...FUNCTION_WORDS]) {
+  if (entry?.word && !VOCAB.has(entry.word)) VOCAB.set(entry.word, entry);
+}
+
+export const VOCAB_LIST: VocabEntry[] = [...VOCAB.values()].sort((a, b) =>
+  a.reading.localeCompare(b.reading, "ja")
+);
+
+export function lookup(word: string): VocabEntry | undefined {
+  return VOCAB.get(word);
+}

--- a/playground/src/vocab/entries/batch-01.ts
+++ b/playground/src/vocab/entries/batch-01.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "1500円", reading: "せんごひゃくえん", romaji: "sengohyakuen", pos: "noun", en: "1500 yen", zh: "1500日元" },
+  { word: "300円", reading: "さんびゃくえん", romaji: "sanbyakuen", pos: "noun", en: "300 yen", zh: "300日元" },
+  { word: "5時", reading: "ごじ", romaji: "goji", pos: "noun", en: "5 o'clock", zh: "5点" },
+  { word: "7時", reading: "しちじ", romaji: "shichiji", pos: "noun", en: "7 o'clock", zh: "7点" },
+  { word: "7時30分", reading: "しちじさんじゅっぷん", romaji: "shichiji sanjuppun", pos: "noun", en: "7:30", zh: "7点30分" },
+  { word: "9時", reading: "くじ", romaji: "kuji", pos: "noun", en: "9 o'clock", zh: "9点" },
+  { word: "あきらめる", reading: "あきらめる", romaji: "akirameru", pos: "verb-ichidan", en: "to give up", zh: "放弃" },
+  { word: "あなた", reading: "あなた", romaji: "anata", pos: "noun", en: "you", zh: "你" },
+  { word: "あの店", reading: "あのみせ", romaji: "ano mise", pos: "noun", en: "that shop", zh: "那家店" },
+  { word: "ある", reading: "ある", romaji: "aru", pos: "verb-godan", en: "to be (inanimate); to exist", zh: "有；在（无生命）" },
+  { word: "いい", reading: "いい", romaji: "ii", pos: "i-adjective", en: "good", zh: "好" },
+  { word: "いたす", reading: "いたす", romaji: "itasu", pos: "verb-godan", en: "to do (humble)", zh: "做（自谦语）" },
+  { word: "いる", reading: "いる", romaji: "iru", pos: "verb-ichidan", en: "to be (animate); to exist", zh: "有；在（有生命）" },
+  { word: "おいしい", reading: "おいしい", romaji: "oishii", pos: "i-adjective", en: "delicious", zh: "好吃" },
+  { word: "おっしゃいました", reading: "おっしゃいました", romaji: "osshaimashita", pos: "noun", en: "said (honorific, past)", zh: "说了（敬语）" },
+  { word: "おもしろい", reading: "おもしろい", romaji: "omoshiroi", pos: "i-adjective", en: "interesting", zh: "有趣" },
+  { word: "お願い", reading: "おねがい", romaji: "onegai", pos: "noun", en: "request; please", zh: "请求；拜托" },
+  { word: "お金", reading: "おかね", romaji: "okane", pos: "noun", en: "money", zh: "钱" },
+  { word: "お金持ち", reading: "おかねもち", romaji: "okanemochi", pos: "noun", en: "rich person", zh: "有钱人" },
+  { word: "お酒", reading: "おさけ", romaji: "osake", pos: "noun", en: "alcohol; sake", zh: "酒" },
+  { word: "お世話", reading: "おせわ", romaji: "osewa", pos: "noun", en: "care; help; assistance", zh: "照顾；关照" },
+  { word: "お茶", reading: "おちゃ", romaji: "ocha", pos: "noun", en: "tea", zh: "茶" },
+  { word: "お湯", reading: "おゆ", romaji: "oyu", pos: "noun", en: "hot water", zh: "热水" },
+  { word: "かける", reading: "かける", romaji: "kakeru", pos: "verb-ichidan", en: "to hang; to make (a call)", zh: "挂；打（电话）" },
+  { word: "かばん", reading: "かばん", romaji: "kaban", pos: "noun", en: "bag", zh: "包" },
+  { word: "きれい", reading: "きれい", romaji: "kirei", pos: "na-adjective", en: "pretty; clean", zh: "漂亮；干净" },
+  { word: "クラス", reading: "クラス", romaji: "kurasu", pos: "noun", en: "class", zh: "班级" },
+  { word: "コート", reading: "コート", romaji: "kōto", pos: "noun", en: "coat", zh: "外套" },
+  { word: "コーヒー", reading: "コーヒー", romaji: "kōhī", pos: "noun", en: "coffee", zh: "咖啡" },
+  { word: "こちら", reading: "こちら", romaji: "kochira", pos: "noun", en: "this way; this person", zh: "这边；这位" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-02.ts
+++ b/playground/src/vocab/entries/batch-02.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "このケーキ", reading: "このケーキ", romaji: "kono kēki", pos: "noun", en: "this cake", zh: "这个蛋糕" },
+  { word: "この町", reading: "このまち", romaji: "kono machi", pos: "noun", en: "this town", zh: "这个城镇" },
+  { word: "この店", reading: "このみせ", romaji: "kono mise", pos: "noun", en: "this shop", zh: "这家店" },
+  { word: "この本", reading: "このほん", romaji: "kono hon", pos: "noun", en: "this book", zh: "这本书" },
+  { word: "ご飯", reading: "ごはん", romaji: "gohan", pos: "noun", en: "cooked rice; meal", zh: "米饭；饭" },
+  { word: "すぐ", reading: "すぐ", romaji: "sugu", pos: "noun", en: "immediately; soon", zh: "马上；立刻" },
+  { word: "する", reading: "する", romaji: "suru", pos: "verb-irregular", en: "to do", zh: "做" },
+  { word: "そんなこと", reading: "そんなこと", romaji: "sonna koto", pos: "noun", en: "such a thing", zh: "那样的事" },
+  { word: "つける", reading: "つける", romaji: "tsukeru", pos: "verb-ichidan", en: "to turn on; to attach", zh: "打开；安装" },
+  { word: "できる", reading: "できる", romaji: "dekiru", pos: "verb-ichidan", en: "to be able to; can do", zh: "能够；会" },
+  { word: "テレビ", reading: "テレビ", romaji: "terebi", pos: "noun", en: "television", zh: "电视" },
+  { word: "ドア", reading: "ドア", romaji: "doa", pos: "noun", en: "door", zh: "门" },
+  { word: "なる", reading: "なる", romaji: "naru", pos: "verb-godan", en: "to become", zh: "成为；变成" },
+  { word: "バス", reading: "バス", romaji: "basu", pos: "noun", en: "bus", zh: "公交车" },
+  { word: "ピアノ", reading: "ピアノ", romaji: "piano", pos: "noun", en: "piano", zh: "钢琴" },
+  { word: "ボタン", reading: "ボタン", romaji: "botan", pos: "noun", en: "button", zh: "按钮；纽扣" },
+  { word: "ほめる", reading: "ほめる", romaji: "homeru", pos: "verb-ichidan", en: "to praise", zh: "表扬；称赞" },
+  { word: "みんな", reading: "みんな", romaji: "minna", pos: "noun", en: "everyone; all", zh: "大家；全部" },
+  { word: "りんご", reading: "りんご", romaji: "ringo", pos: "noun", en: "apple", zh: "苹果" },
+  { word: "レストラン", reading: "レストラン", romaji: "resutoran", pos: "noun", en: "restaurant", zh: "餐厅" },
+  { word: "わかる", reading: "わかる", romaji: "wakaru", pos: "verb-godan", en: "to understand", zh: "明白；懂" },
+  { word: "わさび", reading: "わさび", romaji: "wasabi", pos: "noun", en: "wasabi", zh: "芥末" },
+  { word: "挨拶", reading: "あいさつ", romaji: "aisatsu", pos: "noun", en: "greeting", zh: "问候；打招呼" },
+  { word: "安い", reading: "やすい", romaji: "yasui", pos: "i-adjective", en: "cheap; inexpensive", zh: "便宜" },
+  { word: "医者", reading: "いしゃ", romaji: "isha", pos: "noun", en: "doctor", zh: "医生" },
+  { word: "一週間", reading: "いっしゅうかん", romaji: "isshūkan", pos: "noun", en: "one week", zh: "一周" },
+  { word: "飲む", reading: "のむ", romaji: "nomu", pos: "verb-godan", en: "to drink", zh: "喝" },
+  { word: "右", reading: "みぎ", romaji: "migi", pos: "noun", en: "right (direction)", zh: "右；右边" },
+  { word: "雨", reading: "あめ", romaji: "ame", pos: "noun", en: "rain", zh: "雨" },
+  { word: "営業中", reading: "えいぎょうちゅう", romaji: "eigyōchū", pos: "noun", en: "open (for business)", zh: "营业中" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-03.ts
+++ b/playground/src/vocab/entries/batch-03.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "映画", reading: "えいが", romaji: "eiga", pos: "noun", en: "movie", zh: "电影" },
+  { word: "泳ぐ", reading: "およぐ", romaji: "oyogu", pos: "verb-godan", en: "to swim", zh: "游泳" },
+  { word: "英語", reading: "えいご", romaji: "eigo", pos: "noun", en: "English (language)", zh: "英语" },
+  { word: "駅", reading: "えき", romaji: "eki", pos: "noun", en: "station", zh: "车站" },
+  { word: "押す", reading: "おす", romaji: "osu", pos: "verb-godan", en: "to push", zh: "推；按" },
+  { word: "家", reading: "いえ", romaji: "ie", pos: "noun", en: "house, home", zh: "家；房子" },
+  { word: "暇", reading: "ひま", romaji: "hima", pos: "na-adjective", en: "free (time), idle", zh: "空闲的" },
+  { word: "果物", reading: "くだもの", romaji: "kudamono", pos: "noun", en: "fruit", zh: "水果" },
+  { word: "歌", reading: "うた", romaji: "uta", pos: "noun", en: "song", zh: "歌" },
+  { word: "歌う", reading: "うたう", romaji: "utau", pos: "verb-godan", en: "to sing", zh: "唱歌" },
+  { word: "花", reading: "はな", romaji: "hana", pos: "noun", en: "flower", zh: "花" },
+  { word: "過ぎる", reading: "すぎる", romaji: "sugiru", pos: "verb-ichidan", en: "to pass, to exceed", zh: "经过；超过" },
+  { word: "我々", reading: "われわれ", romaji: "wareware", pos: "noun", en: "we, us", zh: "我们" },
+  { word: "我慢", reading: "がまん", romaji: "gaman", pos: "noun", en: "patience, endurance", zh: "忍耐" },
+  { word: "会う", reading: "あう", romaji: "au", pos: "verb-godan", en: "to meet", zh: "见面" },
+  { word: "会議", reading: "かいぎ", romaji: "kaigi", pos: "noun", en: "meeting, conference", zh: "会议" },
+  { word: "海外", reading: "かいがい", romaji: "kaigai", pos: "noun", en: "overseas, abroad", zh: "海外" },
+  { word: "開く", reading: "ひらく", romaji: "hiraku", pos: "verb-godan", en: "to open", zh: "打开；开" },
+  { word: "開ける", reading: "あける", romaji: "akeru", pos: "verb-ichidan", en: "to open (something)", zh: "打开" },
+  { word: "開会", reading: "かいかい", romaji: "kaikai", pos: "noun", en: "opening of a meeting", zh: "开会" },
+  { word: "外", reading: "そと", romaji: "soto", pos: "noun", en: "outside", zh: "外面" },
+  { word: "確認", reading: "かくにん", romaji: "kakunin", pos: "noun", en: "confirmation, verification", zh: "确认" },
+  { word: "学校", reading: "がっこう", romaji: "gakkō", pos: "noun", en: "school", zh: "学校" },
+  { word: "学生", reading: "がくせい", romaji: "gakusei", pos: "noun", en: "student", zh: "学生" },
+  { word: "楽しい", reading: "たのしい", romaji: "tanoshii", pos: "i-adjective", en: "fun, enjoyable", zh: "快乐的；愉快的" },
+  { word: "噛む", reading: "かむ", romaji: "kamu", pos: "verb-godan", en: "to bite, to chew", zh: "咬；咀嚼" },
+  { word: "寒い", reading: "さむい", romaji: "samui", pos: "i-adjective", en: "cold (weather)", zh: "寒冷的" },
+  { word: "感動", reading: "かんどう", romaji: "kandō", pos: "noun", en: "being moved, deep emotion", zh: "感动" },
+  { word: "漢字", reading: "かんじ", romaji: "kanji", pos: "noun", en: "kanji, Chinese characters", zh: "汉字" },
+  { word: "間に合う", reading: "まにあう", romaji: "maniau", pos: "verb-godan", en: "to be in time", zh: "来得及；赶上" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-04.ts
+++ b/playground/src/vocab/entries/batch-04.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "眼鏡", reading: "めがね", romaji: "megane", pos: "noun", en: "glasses, eyeglasses", zh: "眼镜" },
+  { word: "机の上", reading: "つくえのうえ", romaji: "tsukue no ue", pos: "noun", en: "on the desk", zh: "桌子上" },
+  { word: "帰る", reading: "かえる", romaji: "kaeru", pos: "verb-godan", en: "to return, to go home", zh: "回去，回家" },
+  { word: "気分", reading: "きぶん", romaji: "kibun", pos: "noun", en: "feeling, mood", zh: "心情，情绪" },
+  { word: "規則", reading: "きそく", romaji: "kisoku", pos: "noun", en: "rule, regulation", zh: "规则" },
+  { word: "起きる", reading: "おきる", romaji: "okiru", pos: "verb-ichidan", en: "to get up, to wake up", zh: "起床，发生" },
+  { word: "疑う", reading: "うたがう", romaji: "utagau", pos: "verb-godan", en: "to doubt, to suspect", zh: "怀疑" },
+  { word: "議論", reading: "ぎろん", romaji: "giron", pos: "noun", en: "discussion, argument", zh: "讨论，争论" },
+  { word: "休む", reading: "やすむ", romaji: "yasumu", pos: "verb-godan", en: "to rest, to take a day off", zh: "休息，请假" },
+  { word: "吸う", reading: "すう", romaji: "suu", pos: "verb-godan", en: "to inhale, to smoke", zh: "吸，抽（烟）" },
+  { word: "急ぐ", reading: "いそぐ", romaji: "isogu", pos: "verb-godan", en: "to hurry", zh: "急，赶紧" },
+  { word: "泣く", reading: "なく", romaji: "naku", pos: "verb-godan", en: "to cry", zh: "哭" },
+  { word: "教える", reading: "おしえる", romaji: "oshieru", pos: "verb-ichidan", en: "to teach, to tell", zh: "教，告诉" },
+  { word: "教室", reading: "きょうしつ", romaji: "kyōshitsu", pos: "noun", en: "classroom", zh: "教室" },
+  { word: "曲がる", reading: "まがる", romaji: "magaru", pos: "verb-godan", en: "to turn, to bend", zh: "转弯，弯曲" },
+  { word: "銀行", reading: "ぎんこう", romaji: "ginkō", pos: "noun", en: "bank", zh: "银行" },
+  { word: "兄", reading: "あに", romaji: "ani", pos: "noun", en: "older brother", zh: "哥哥" },
+  { word: "契約", reading: "けいやく", romaji: "keiyaku", pos: "noun", en: "contract, agreement", zh: "合同，契约" },
+  { word: "計画", reading: "けいかく", romaji: "keikaku", pos: "noun", en: "plan", zh: "计划" },
+  { word: "決める", reading: "きめる", romaji: "kimeru", pos: "verb-ichidan", en: "to decide", zh: "决定" },
+  { word: "決意", reading: "けつい", romaji: "ketsui", pos: "noun", en: "determination, resolve", zh: "决心，决意" },
+  { word: "結果", reading: "けっか", romaji: "kekka", pos: "noun", en: "result, outcome", zh: "结果" },
+  { word: "犬", reading: "いぬ", romaji: "inu", pos: "noun", en: "dog", zh: "狗" },
+  { word: "見せる", reading: "みせる", romaji: "miseru", pos: "verb-ichidan", en: "to show", zh: "给…看，出示" },
+  { word: "見る", reading: "みる", romaji: "miru", pos: "verb-ichidan", en: "to see, to watch", zh: "看" },
+  { word: "元気", reading: "げんき", romaji: "genki", pos: "na-adjective", en: "healthy, energetic", zh: "健康，精神好" },
+  { word: "厳しい", reading: "きびしい", romaji: "kibishii", pos: "i-adjective", en: "strict, severe", zh: "严厉，严格" },
+  { word: "言い訳", reading: "いいわけ", romaji: "iiwake", pos: "noun", en: "excuse", zh: "借口，辩解" },
+  { word: "言う", reading: "いう", romaji: "iu", pos: "verb-godan", en: "to say", zh: "说" },
+  { word: "言語", reading: "げんご", romaji: "gengo", pos: "noun", en: "language", zh: "语言" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-05.ts
+++ b/playground/src/vocab/entries/batch-05.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "午後3時", reading: "ごごさんじ", romaji: "gogo sanji", pos: "noun", en: "3 p.m.", zh: "下午三点" },
+  { word: "公園", reading: "こうえん", romaji: "kōen", pos: "noun", en: "park", zh: "公园" },
+  { word: "好き", reading: "すき", romaji: "suki", pos: "na-adjective", en: "liked, favorite", zh: "喜欢" },
+  { word: "幸せ", reading: "しあわせ", romaji: "shiawase", pos: "na-adjective", en: "happy", zh: "幸福" },
+  { word: "考える", reading: "かんがえる", romaji: "kangaeru", pos: "verb-ichidan", en: "to think, to consider", zh: "思考" },
+  { word: "行く", reading: "いく", romaji: "iku", pos: "verb-godan", en: "to go", zh: "去" },
+  { word: "行動", reading: "こうどう", romaji: "kōdō", pos: "noun", en: "action, conduct", zh: "行动" },
+  { word: "降る", reading: "ふる", romaji: "furu", pos: "verb-godan", en: "to fall (rain, snow)", zh: "下（雨、雪）" },
+  { word: "高い", reading: "たかい", romaji: "takai", pos: "i-adjective", en: "high, expensive", zh: "高、贵" },
+  { word: "国内", reading: "こくない", romaji: "kokunai", pos: "noun", en: "domestic, within the country", zh: "国内" },
+  { word: "今", reading: "いま", romaji: "ima", pos: "noun", en: "now", zh: "现在" },
+  { word: "今日", reading: "きょう", romaji: "kyō", pos: "noun", en: "today", zh: "今天" },
+  { word: "財布", reading: "さいふ", romaji: "saifu", pos: "noun", en: "wallet", zh: "钱包" },
+  { word: "咲く", reading: "さく", romaji: "saku", pos: "verb-godan", en: "to bloom", zh: "开花" },
+  { word: "昨日", reading: "きのう", romaji: "kinō", pos: "noun", en: "yesterday", zh: "昨天" },
+  { word: "撮る", reading: "とる", romaji: "toru", pos: "verb-godan", en: "to take (a photo)", zh: "拍摄" },
+  { word: "三つ", reading: "みっつ", romaji: "mittsu", pos: "noun", en: "three (things)", zh: "三个" },
+  { word: "傘", reading: "かさ", romaji: "kasa", pos: "noun", en: "umbrella", zh: "伞" },
+  { word: "参る", reading: "まいる", romaji: "mairu", pos: "verb-godan", en: "to go, to come (humble)", zh: "去、来（自谦语）" },
+  { word: "山", reading: "やま", romaji: "yama", pos: "noun", en: "mountain", zh: "山" },
+  { word: "仕事", reading: "しごと", romaji: "shigoto", pos: "noun", en: "work, job", zh: "工作" },
+  { word: "使う", reading: "つかう", romaji: "tsukau", pos: "verb-godan", en: "to use", zh: "使用" },
+  { word: "刺身", reading: "さしみ", romaji: "sashimi", pos: "noun", en: "sashimi", zh: "生鱼片" },
+  { word: "姉", reading: "あね", romaji: "ane", pos: "noun", en: "older sister", zh: "姐姐" },
+  { word: "子供", reading: "こども", romaji: "kodomo", pos: "noun", en: "child", zh: "孩子" },
+  { word: "子供の頃", reading: "こどものころ", romaji: "kodomo no koro", pos: "noun", en: "childhood", zh: "小时候" },
+  { word: "私", reading: "わたし", romaji: "watashi", pos: "noun", en: "I, me", zh: "我" },
+  { word: "私の趣味", reading: "わたしのしゅみ", romaji: "watashi no shumi", pos: "noun", en: "my hobby", zh: "我的爱好" },
+  { word: "資料", reading: "しりょう", romaji: "shiryō", pos: "noun", en: "materials, documents", zh: "资料" },
+  { word: "持つ", reading: "もつ", romaji: "motsu", pos: "verb-godan", en: "to hold, to have", zh: "拿、持有" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-06.ts
+++ b/playground/src/vocab/entries/batch-06.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "時間", reading: "じかん", romaji: "jikan", pos: "noun", en: "time; hour", zh: "时间" },
+  { word: "治る", reading: "なおる", romaji: "naoru", pos: "verb-godan", en: "to be cured; to heal", zh: "痊愈；治好" },
+  { word: "辞書", reading: "じしょ", romaji: "jisho", pos: "noun", en: "dictionary", zh: "词典" },
+  { word: "叱る", reading: "しかる", romaji: "shikaru", pos: "verb-godan", en: "to scold", zh: "责骂；训斥" },
+  { word: "失敗", reading: "しっぱい", romaji: "shippai", pos: "noun", en: "failure", zh: "失败" },
+  { word: "写真", reading: "しゃしん", romaji: "shashin", pos: "noun", en: "photograph", zh: "照片" },
+  { word: "社長", reading: "しゃちょう", romaji: "shachō", pos: "noun", en: "company president", zh: "社长；总经理" },
+  { word: "車", reading: "くるま", romaji: "kuruma", pos: "noun", en: "car", zh: "车；汽车" },
+  { word: "借りる", reading: "かりる", romaji: "kariru", pos: "verb-ichidan", en: "to borrow", zh: "借（入）" },
+  { word: "守る", reading: "まもる", romaji: "mamoru", pos: "verb-godan", en: "to protect; to keep", zh: "保护；遵守" },
+  { word: "手", reading: "て", romaji: "te", pos: "noun", en: "hand", zh: "手" },
+  { word: "手伝う", reading: "てつだう", romaji: "tetsudau", pos: "verb-godan", en: "to help", zh: "帮忙" },
+  { word: "受付", reading: "うけつけ", romaji: "uketsuke", pos: "noun", en: "reception", zh: "接待处；前台" },
+  { word: "寿司", reading: "すし", romaji: "sushi", pos: "noun", en: "sushi", zh: "寿司" },
+  { word: "授業", reading: "じゅぎょう", romaji: "jugyō", pos: "noun", en: "class; lesson", zh: "课；上课" },
+  { word: "終わる", reading: "おわる", romaji: "owaru", pos: "verb-godan", en: "to end; to finish", zh: "结束；完了" },
+  { word: "住む", reading: "すむ", romaji: "sumu", pos: "verb-godan", en: "to live; to reside", zh: "居住" },
+  { word: "重要", reading: "じゅうよう", romaji: "jūyō", pos: "na-adjective", en: "important", zh: "重要" },
+  { word: "出る", reading: "でる", romaji: "deru", pos: "verb-ichidan", en: "to go out; to leave", zh: "出去；出来" },
+  { word: "春", reading: "はる", romaji: "haru", pos: "noun", en: "spring", zh: "春天" },
+  { word: "暑い", reading: "あつい", romaji: "atsui", pos: "i-adjective", en: "hot (weather)", zh: "热（天气）" },
+  { word: "書く", reading: "かく", romaji: "kaku", pos: "verb-godan", en: "to write", zh: "写" },
+  { word: "書類", reading: "しょるい", romaji: "shorui", pos: "noun", en: "documents", zh: "文件；资料" },
+  { word: "消える", reading: "きえる", romaji: "kieru", pos: "verb-ichidan", en: "to disappear; to go out", zh: "消失；熄灭" },
+  { word: "消す", reading: "けす", romaji: "kesu", pos: "verb-godan", en: "to erase; to turn off", zh: "消除；关掉" },
+  { word: "笑う", reading: "わらう", romaji: "warau", pos: "verb-godan", en: "to laugh; to smile", zh: "笑" },
+  { word: "証拠", reading: "しょうこ", romaji: "shōko", pos: "noun", en: "evidence; proof", zh: "证据" },
+  { word: "上手", reading: "じょうず", romaji: "jōzu", pos: "noun", en: "skillful; good at", zh: "擅长；高明" },
+  { word: "冗談", reading: "じょうだん", romaji: "jōdan", pos: "noun", en: "joke", zh: "玩笑" },
+  { word: "食べる", reading: "たべる", romaji: "taberu", pos: "verb-ichidan", en: "to eat", zh: "吃" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-07.ts
+++ b/playground/src/vocab/entries/batch-07.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "寝る", reading: "ねる", romaji: "neru", pos: "verb-ichidan", en: "to sleep; to go to bed", zh: "睡觉" },
+  { word: "心配", reading: "しんぱい", romaji: "shinpai", pos: "noun", en: "worry; anxiety", zh: "担心；忧虑" },
+  { word: "新しい", reading: "あたらしい", romaji: "atarashii", pos: "i-adjective", en: "new", zh: "新的" },
+  { word: "新年", reading: "しんねん", romaji: "shinnen", pos: "noun", en: "new year", zh: "新年" },
+  { word: "新聞", reading: "しんぶん", romaji: "shinbun", pos: "noun", en: "newspaper", zh: "报纸" },
+  { word: "申す", reading: "もうす", romaji: "mōsu", pos: "verb-godan", en: "to say (humble)", zh: "说（谦语）" },
+  { word: "真実", reading: "しんじつ", romaji: "shinjitsu", pos: "noun", en: "truth", zh: "真实；事实" },
+  { word: "人", reading: "ひと", romaji: "hito", pos: "noun", en: "person", zh: "人" },
+  { word: "図書館", reading: "としょかん", romaji: "toshokan", pos: "noun", en: "library", zh: "图书馆" },
+  { word: "水", reading: "みず", romaji: "mizu", pos: "noun", en: "water", zh: "水" },
+  { word: "成功", reading: "せいこう", romaji: "seikō", pos: "noun", en: "success", zh: "成功" },
+  { word: "正しい", reading: "ただしい", romaji: "tadashii", pos: "i-adjective", en: "correct; right", zh: "正确的" },
+  { word: "声", reading: "こえ", romaji: "koe", pos: "noun", en: "voice", zh: "声音" },
+  { word: "静か", reading: "しずか", romaji: "shizuka", pos: "na-adjective", en: "quiet", zh: "安静的" },
+  { word: "昔", reading: "むかし", romaji: "mukashi", pos: "noun", en: "old times; the past", zh: "从前；过去" },
+  { word: "赤い", reading: "あかい", romaji: "akai", pos: "i-adjective", en: "red", zh: "红色的" },
+  { word: "赤ちゃん", reading: "あかちゃん", romaji: "akachan", pos: "noun", en: "baby", zh: "婴儿" },
+  { word: "切符", reading: "きっぷ", romaji: "kippu", pos: "noun", en: "ticket", zh: "票" },
+  { word: "説明", reading: "せつめい", romaji: "setsumei", pos: "noun", en: "explanation", zh: "说明；解释" },
+  { word: "先生", reading: "せんせい", romaji: "sensei", pos: "noun", en: "teacher", zh: "老师" },
+  { word: "千円", reading: "せんえん", romaji: "sen'en", pos: "noun", en: "one thousand yen", zh: "一千日元" },
+  { word: "洗う", reading: "あらう", romaji: "arau", pos: "verb-godan", en: "to wash", zh: "洗" },
+  { word: "素晴らしい", reading: "すばらしい", romaji: "subarashii", pos: "i-adjective", en: "wonderful; splendid", zh: "极好的；了不起的" },
+  { word: "窓", reading: "まど", romaji: "mado", pos: "noun", en: "window", zh: "窗户" },
+  { word: "送る", reading: "おくる", romaji: "okuru", pos: "verb-godan", en: "to send", zh: "送；寄" },
+  { word: "速い", reading: "はやい", romaji: "hayai", pos: "i-adjective", en: "fast; quick", zh: "快的" },
+  { word: "続く", reading: "つづく", romaji: "tsuzuku", pos: "verb-godan", en: "to continue", zh: "持续；继续" },
+  { word: "卒業", reading: "そつぎょう", romaji: "sotsugyō", pos: "noun", en: "graduation", zh: "毕业" },
+  { word: "対立", reading: "たいりつ", romaji: "tairitsu", pos: "noun", en: "confrontation; opposition", zh: "对立；冲突" },
+  { word: "待つ", reading: "まつ", romaji: "matsu", pos: "verb-godan", en: "to wait", zh: "等待" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-08.ts
+++ b/playground/src/vocab/entries/batch-08.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "貸す", reading: "かす", romaji: "kasu", pos: "verb-godan", en: "to lend", zh: "借出，出借" },
+  { word: "大きい", reading: "おおきい", romaji: "ōkii", pos: "i-adjective", en: "big", zh: "大的" },
+  { word: "大阪", reading: "おおさか", romaji: "Ōsaka", pos: "noun", en: "Osaka", zh: "大阪" },
+  { word: "脱ぐ", reading: "ぬぐ", romaji: "nugu", pos: "verb-godan", en: "to take off (clothes)", zh: "脱（衣服）" },
+  { word: "弾く", reading: "ひく", romaji: "hiku", pos: "verb-godan", en: "to play (an instrument)", zh: "弹奏（乐器）" },
+  { word: "暖かい", reading: "あたたかい", romaji: "atatakai", pos: "i-adjective", en: "warm", zh: "暖和的" },
+  { word: "知る", reading: "しる", romaji: "shiru", pos: "verb-godan", en: "to know", zh: "知道" },
+  { word: "遅れる", reading: "おくれる", romaji: "okureru", pos: "verb-ichidan", en: "to be late", zh: "迟到，晚点" },
+  { word: "着く", reading: "つく", romaji: "tsuku", pos: "verb-godan", en: "to arrive", zh: "到达" },
+  { word: "着る", reading: "きる", romaji: "kiru", pos: "verb-ichidan", en: "to wear", zh: "穿（衣服）" },
+  { word: "中国語", reading: "ちゅうごくご", romaji: "chūgokugo", pos: "noun", en: "Chinese (language)", zh: "汉语" },
+  { word: "中止", reading: "ちゅうし", romaji: "chūshi", pos: "noun", en: "cancellation, suspension", zh: "中止，取消" },
+  { word: "朝ご飯", reading: "あさごはん", romaji: "asagohan", pos: "noun", en: "breakfast", zh: "早饭" },
+  { word: "町", reading: "まち", romaji: "machi", pos: "noun", en: "town", zh: "城镇" },
+  { word: "弟", reading: "おとうと", romaji: "otōto", pos: "noun", en: "younger brother", zh: "弟弟" },
+  { word: "諦める", reading: "あきらめる", romaji: "akirameru", pos: "verb-ichidan", en: "to give up", zh: "放弃" },
+  { word: "天気", reading: "てんき", romaji: "tenki", pos: "noun", en: "weather", zh: "天气" },
+  { word: "店", reading: "みせ", romaji: "mise", pos: "noun", en: "shop, store", zh: "商店" },
+  { word: "田中", reading: "たなか", romaji: "Tanaka", pos: "noun", en: "Tanaka (surname)", zh: "田中（姓氏）" },
+  { word: "田中さん", reading: "たなかさん", romaji: "Tanaka-san", pos: "noun", en: "Mr./Ms. Tanaka", zh: "田中先生／女士" },
+  { word: "電気", reading: "でんき", romaji: "denki", pos: "noun", en: "electricity, light", zh: "电，电灯" },
+  { word: "電車", reading: "でんしゃ", romaji: "densha", pos: "noun", en: "train", zh: "电车" },
+  { word: "努力", reading: "どりょく", romaji: "doryoku", pos: "noun", en: "effort", zh: "努力" },
+  { word: "東京", reading: "とうきょう", romaji: "Tōkyō", pos: "noun", en: "Tokyo", zh: "东京" },
+  { word: "盗む", reading: "ぬすむ", romaji: "nusumu", pos: "verb-godan", en: "to steal", zh: "偷窃" },
+  { word: "働く", reading: "はたらく", romaji: "hataraku", pos: "verb-godan", en: "to work", zh: "工作" },
+  { word: "読む", reading: "よむ", romaji: "yomu", pos: "verb-godan", en: "to read", zh: "读，阅读" },
+  { word: "難しい", reading: "むずかしい", romaji: "muzukashii", pos: "i-adjective", en: "difficult", zh: "难的" },
+  { word: "二人", reading: "ふたり", romaji: "futari", pos: "noun", en: "two people", zh: "两个人" },
+  { word: "二枚", reading: "にまい", romaji: "nimai", pos: "noun", en: "two (flat objects)", zh: "两张（薄平物）" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-09.ts
+++ b/playground/src/vocab/entries/batch-09.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "肉", reading: "にく", romaji: "niku", pos: "noun", en: "meat", zh: "肉" },
+  { word: "日本", reading: "にほん", romaji: "nihon", pos: "noun", en: "Japan", zh: "日本" },
+  { word: "日本語", reading: "にほんご", romaji: "nihongo", pos: "noun", en: "Japanese language", zh: "日语" },
+  { word: "日本人", reading: "にほんじん", romaji: "nihonjin", pos: "noun", en: "Japanese person", zh: "日本人" },
+  { word: "日曜日", reading: "にちようび", romaji: "nichiyōbi", pos: "noun", en: "Sunday", zh: "星期日" },
+  { word: "入る", reading: "はいる", romaji: "hairu", pos: "verb-godan", en: "to enter", zh: "进入" },
+  { word: "入れる", reading: "いれる", romaji: "ireru", pos: "verb-ichidan", en: "to put in", zh: "放入" },
+  { word: "認める", reading: "みとめる", romaji: "mitomeru", pos: "verb-ichidan", en: "to acknowledge", zh: "承认" },
+  { word: "猫", reading: "ねこ", romaji: "neko", pos: "noun", en: "cat", zh: "猫" },
+  { word: "買う", reading: "かう", romaji: "kau", pos: "verb-godan", en: "to buy", zh: "买" },
+  { word: "白い", reading: "しろい", romaji: "shiroi", pos: "i-adjective", en: "white", zh: "白色的" },
+  { word: "判断", reading: "はんだん", romaji: "handan", pos: "noun", en: "judgment", zh: "判断" },
+  { word: "犯人", reading: "はんにん", romaji: "hannin", pos: "noun", en: "culprit", zh: "犯人" },
+  { word: "彼", reading: "かれ", romaji: "kare", pos: "noun", en: "he", zh: "他" },
+  { word: "彼女", reading: "かのじょ", romaji: "kanojo", pos: "noun", en: "she", zh: "她" },
+  { word: "美しい", reading: "うつくしい", romaji: "utsukushii", pos: "i-adjective", en: "beautiful", zh: "美丽的" },
+  { word: "病院", reading: "びょういん", romaji: "byōin", pos: "noun", en: "hospital", zh: "医院" },
+  { word: "病気", reading: "びょうき", romaji: "byōki", pos: "noun", en: "illness", zh: "疾病" },
+  { word: "貧乏", reading: "びんぼう", romaji: "binbō", pos: "noun", en: "poverty", zh: "贫穷" },
+  { word: "不便", reading: "ふべん", romaji: "fuben", pos: "na-adjective", en: "inconvenient", zh: "不方便" },
+  { word: "富士山", reading: "ふじさん", romaji: "fujisan", pos: "noun", en: "Mount Fuji", zh: "富士山" },
+  { word: "父", reading: "ちち", romaji: "chichi", pos: "noun", en: "father", zh: "父亲" },
+  { word: "部屋", reading: "へや", romaji: "heya", pos: "noun", en: "room", zh: "房间" },
+  { word: "部長", reading: "ぶちょう", romaji: "buchō", pos: "noun", en: "department manager", zh: "部长" },
+  { word: "分かる", reading: "わかる", romaji: "wakaru", pos: "verb-godan", en: "to understand", zh: "明白" },
+  { word: "文化", reading: "ぶんか", romaji: "bunka", pos: "noun", en: "culture", zh: "文化" },
+  { word: "聞く", reading: "きく", romaji: "kiku", pos: "verb-godan", en: "to listen, to ask", zh: "听，问" },
+  { word: "閉まる", reading: "しまる", romaji: "shimaru", pos: "verb-godan", en: "to close (intransitive)", zh: "关闭" },
+  { word: "閉める", reading: "しめる", romaji: "shimeru", pos: "verb-ichidan", en: "to close (transitive)", zh: "关上" },
+  { word: "便利", reading: "べんり", romaji: "benri", pos: "noun", en: "convenient", zh: "方便" },
+];
+
+export default entries;

--- a/playground/src/vocab/entries/batch-10.ts
+++ b/playground/src/vocab/entries/batch-10.ts
@@ -1,0 +1,36 @@
+import type { VocabEntry } from "../types";
+
+const entries: VocabEntry[] = [
+  { word: "歩く", reading: "あるく", romaji: "aruku", pos: "verb-godan", en: "to walk", zh: "走，步行" },
+  { word: "母", reading: "はは", romaji: "haha", pos: "noun", en: "mother", zh: "母亲" },
+  { word: "忘れる", reading: "わすれる", romaji: "wasureru", pos: "verb-ichidan", en: "to forget", zh: "忘记" },
+  { word: "忙しい", reading: "いそがしい", romaji: "isogashii", pos: "i-adjective", en: "busy", zh: "忙碌的" },
+  { word: "本", reading: "ほん", romaji: "hon", pos: "noun", en: "book", zh: "书" },
+  { word: "本当のこと", reading: "ほんとうのこと", romaji: "hontō no koto", pos: "noun", en: "the truth", zh: "真实的事情" },
+  { word: "眠い", reading: "ねむい", romaji: "nemui", pos: "i-adjective", en: "sleepy", zh: "困的，想睡的" },
+  { word: "夢", reading: "ゆめ", romaji: "yume", pos: "noun", en: "dream", zh: "梦，梦想" },
+  { word: "名前", reading: "なまえ", romaji: "namae", pos: "noun", en: "name", zh: "名字" },
+  { word: "明日", reading: "あした", romaji: "ashita", pos: "noun", en: "tomorrow", zh: "明天" },
+  { word: "面白い", reading: "おもしろい", romaji: "omoshiroi", pos: "i-adjective", en: "interesting", zh: "有趣的" },
+  { word: "問題", reading: "もんだい", romaji: "mondai", pos: "noun", en: "problem; question", zh: "问题" },
+  { word: "野菜", reading: "やさい", romaji: "yasai", pos: "noun", en: "vegetable", zh: "蔬菜" },
+  { word: "薬", reading: "くすり", romaji: "kusuri", pos: "noun", en: "medicine", zh: "药" },
+  { word: "優しい", reading: "やさしい", romaji: "yasashii", pos: "i-adjective", en: "kind; gentle", zh: "温柔的，亲切的" },
+  { word: "友達", reading: "ともだち", romaji: "tomodachi", pos: "noun", en: "friend", zh: "朋友" },
+  { word: "有名", reading: "ゆうめい", romaji: "yūmei", pos: "noun", en: "famous", zh: "有名" },
+  { word: "遊ぶ", reading: "あそぶ", romaji: "asobu", pos: "verb-godan", en: "to play", zh: "玩耍" },
+  { word: "予算", reading: "よさん", romaji: "yosan", pos: "noun", en: "budget", zh: "预算" },
+  { word: "予約", reading: "よやく", romaji: "yoyaku", pos: "noun", en: "reservation", zh: "预约" },
+  { word: "来る", reading: "くる", romaji: "kuru", pos: "verb-irregular", en: "to come", zh: "来" },
+  { word: "来週", reading: "らいしゅう", romaji: "raishū", pos: "noun", en: "next week", zh: "下周" },
+  { word: "来店", reading: "らいてん", romaji: "raiten", pos: "noun", en: "visiting a store", zh: "光临（到店）" },
+  { word: "履く", reading: "はく", romaji: "haku", pos: "verb-godan", en: "to put on (footwear)", zh: "穿（鞋袜）" },
+  { word: "留学", reading: "りゅうがく", romaji: "ryūgaku", pos: "noun", en: "studying abroad", zh: "留学" },
+  { word: "旅行", reading: "りょこう", romaji: "ryokō", pos: "noun", en: "travel; trip", zh: "旅行" },
+  { word: "料理", reading: "りょうり", romaji: "ryōri", pos: "noun", en: "cooking; cuisine", zh: "料理，菜肴" },
+  { word: "連絡", reading: "れんらく", romaji: "renraku", pos: "noun", en: "contact; communication", zh: "联系" },
+  { word: "話", reading: "はなし", romaji: "hanashi", pos: "noun", en: "story; talk", zh: "话，故事" },
+  { word: "話す", reading: "はなす", romaji: "hanasu", pos: "verb-godan", en: "to speak; to talk", zh: "说，谈" },
+];
+
+export default entries;

--- a/playground/src/vocab/extract.ts
+++ b/playground/src/vocab/extract.ts
@@ -1,0 +1,56 @@
+import type { PartOfSpeech } from "./types";
+
+/**
+ * Pull the content words (nouns, verbs, adjectives) out of an example's Typed
+ * Japanese snippet. The snippets follow a consistent shape, so lightweight
+ * regexes are reliable here — and synchronous, so cards can render word lists
+ * without invoking the compiler.
+ */
+export interface ExtractedWord {
+  word: string;
+  pos: PartOfSpeech;
+}
+
+export function extractWords(code: string): ExtractedWord[] {
+  const found: ExtractedWord[] = [];
+  const seen = new Set<string>();
+  const push = (word: string, pos: PartOfSpeech) => {
+    if (word && !seen.has(word)) {
+      seen.add(word);
+      found.push({ word, pos });
+    }
+  };
+
+  // ProperNoun<"X">
+  for (const m of code.matchAll(/ProperNoun<\s*"([^"]+)"\s*>/g)) push(m[1]!, "noun");
+
+  // GodanVerb & { stem: "X"; ending: "Y" }
+  for (const m of code.matchAll(
+    /GodanVerb\s*&\s*\{[^}]*?stem:\s*"([^"]+)"[^}]*?ending:\s*"([^"]+)"/g
+  ))
+    push(m[1]! + m[2]!, "verb-godan");
+
+  // IchidanVerb & { stem: "X"; ending?: "る" }
+  for (const m of code.matchAll(
+    /IchidanVerb\s*&\s*\{[^}]*?stem:\s*"([^"]+)"(?:[^}]*?ending:\s*"([^"]+)")?/g
+  ))
+    push(m[1]! + (m[2] ?? "る"), "verb-ichidan");
+
+  // IrregularVerb & { dictionary: "X" }
+  for (const m of code.matchAll(
+    /IrregularVerb\s*&\s*\{[^}]*?dictionary:\s*"([^"]+)"/g
+  ))
+    push(m[1]!, "verb-irregular");
+
+  // IAdjective & { stem: "X"; ending: "い" }
+  for (const m of code.matchAll(
+    /IAdjective\s*&\s*\{[^}]*?stem:\s*"([^"]+)"(?:[^}]*?ending:\s*"([^"]+)")?/g
+  ))
+    push(m[1]! + (m[2] ?? "い"), "i-adjective");
+
+  // NaAdjective & { stem: "X" }
+  for (const m of code.matchAll(/NaAdjective\s*&\s*\{[^}]*?stem:\s*"([^"]+)"/g))
+    push(m[1]!, "na-adjective");
+
+  return found;
+}

--- a/playground/src/vocab/function-words.ts
+++ b/playground/src/vocab/function-words.ts
@@ -1,0 +1,104 @@
+import type { VocabEntry } from "./types";
+
+/**
+ * Hand-maintained grammar vocabulary: particles, the copula, common auxiliary
+ * suffixes, demonstratives and interrogatives. These give readings/meanings for
+ * the grammatical glue in sentences (は = wa, です = desu, …), complementing the
+ * content words authored under entries/.
+ */
+const e = (
+  word: string,
+  reading: string,
+  romaji: string,
+  pos: VocabEntry["pos"],
+  en: string,
+  zh: string
+): VocabEntry => ({ word, reading, romaji, pos, en, zh });
+
+export const FUNCTION_WORDS: VocabEntry[] = [
+  // particles
+  e("は", "は", "wa", "particle", "topic marker", "提示主题"),
+  e("が", "が", "ga", "particle", "subject marker", "主语标记"),
+  e("を", "を", "o", "particle", "direct-object marker", "宾语标记"),
+  e("に", "に", "ni", "particle", "to / at / for (target, time)", "向、在、给(对象、时间)"),
+  e("へ", "へ", "e", "particle", "to / toward (direction)", "向、往(方向)"),
+  e("で", "で", "de", "particle", "by / at (means, place of action)", "用、在(方式、场所)"),
+  e("と", "と", "to", "particle", "and / with / that (quote)", "和、与、(引用)"),
+  e("から", "から", "kara", "particle", "from / because", "从、因为"),
+  e("まで", "まで", "made", "particle", "until / as far as", "到、为止"),
+  e("よ", "よ", "yo", "particle", "emphasis (sentence-final)", "句末强调"),
+  e("ね", "ね", "ne", "particle", "seeking agreement (right?)", "寻求认同(…吧)"),
+  e("か", "か", "ka", "particle", "question marker", "疑问"),
+  e("よね", "よね", "yone", "particle", "emphasis + agreement", "强调并寻求认同"),
+  e("の", "の", "no", "particle", "possessive / nominalizer", "的、名词化"),
+  e("も", "も", "mo", "particle", "also / even", "也、连…都"),
+
+  // copula
+  e("です", "です", "desu", "copula", "is/are (polite)", "是(礼貌)"),
+  e("だ", "だ", "da", "copula", "is/are (plain)", "是(简体)"),
+  e("でした", "でした", "deshita", "copula", "was/were (polite)", "(过去)是"),
+  e("ではありません", "ではありません", "dewa arimasen", "copula", "is/are not (polite)", "不是(礼貌)"),
+  e("である", "である", "de aru", "copula", "is/are (written)", "是(书面)"),
+
+  // verbal suffixes / auxiliaries
+  e("ます", "ます", "masu", "suffix", "polite non-past", "礼貌体(现在/将来)"),
+  e("ました", "ました", "mashita", "suffix", "polite past", "礼貌体过去"),
+  e("ません", "ません", "masen", "suffix", "polite negative", "礼貌体否定"),
+  e("ませんでした", "ませんでした", "masen deshita", "suffix", "polite past negative", "礼貌体过去否定"),
+  e("ない", "ない", "nai", "suffix", "plain negative", "简体否定"),
+  e("た", "た", "ta", "suffix", "plain past", "简体过去"),
+  e("て", "て", "te", "suffix", "te-form (connective)", "て形(连接)"),
+  e("たい", "たい", "tai", "suffix", "want to (do)", "想(做)"),
+  e("でしょう", "でしょう", "deshou", "suffix", "probably / right?", "大概、…吧"),
+  e("だろう", "だろう", "darou", "suffix", "probably (plain)", "大概(简体)"),
+  e("ましょう", "ましょう", "mashou", "suffix", "let's (do)", "…吧(劝诱)"),
+  e("ください", "ください", "kudasai", "suffix", "please (do)", "请(做)"),
+
+  // conditionals / connectives
+  e("なら", "なら", "nara", "particle", "if (it's the case that)", "如果…的话"),
+  e("たら", "たら", "tara", "particle", "if / when", "如果、…的时候"),
+  e("れば", "れば", "reba", "particle", "if (conditional)", "如果(条件)"),
+  e("ので", "ので", "node", "particle", "because (soft)", "因为(委婉)"),
+  e("けど", "けど", "kedo", "particle", "but / although", "但是、虽然"),
+  e("のに", "のに", "noni", "particle", "although (unexpected)", "却、明明"),
+  e("し", "し", "shi", "particle", "and (listing reasons)", "又…又…"),
+
+  // demonstratives
+  e("これ", "これ", "kore", "pronoun", "this (thing)", "这个"),
+  e("それ", "それ", "sore", "pronoun", "that (near you)", "那个"),
+  e("あれ", "あれ", "are", "pronoun", "that (over there)", "那个(远)"),
+  e("この", "この", "kono", "prefix", "this (+ noun)", "这(个)…"),
+  e("その", "その", "sono", "prefix", "that (+ noun)", "那(个)…"),
+  e("あの", "あの", "ano", "prefix", "that (+ noun, far)", "那(个)…(远)"),
+  e("ここ", "ここ", "koko", "pronoun", "here", "这里"),
+  e("そこ", "そこ", "soko", "pronoun", "there", "那里"),
+  e("あそこ", "あそこ", "asoko", "pronoun", "over there", "那里(远)"),
+  e("こう", "こう", "kou", "adverb", "this way / like this", "这样"),
+  e("そう", "そう", "sou", "adverb", "that way / so", "那样、так"),
+  e("ああ", "ああ", "aa", "adverb", "that way (far)", "那样(远)"),
+  e("どう", "どう", "dou", "adverb", "how / what way", "怎么、如何"),
+
+  // interrogatives
+  e("何", "なに", "nani", "pronoun", "what", "什么"),
+  e("なに", "なに", "nani", "pronoun", "what", "什么"),
+  e("なぜ", "なぜ", "naze", "adverb", "why", "为什么"),
+  e("なんで", "なんで", "nande", "adverb", "why (casual)", "为什么(口语)"),
+  e("どうして", "どうして", "doushite", "adverb", "why / how come", "为什么"),
+  e("いつ", "いつ", "itsu", "pronoun", "when", "什么时候"),
+  e("どこ", "どこ", "doko", "pronoun", "where", "哪里"),
+  e("だれ", "だれ", "dare", "pronoun", "who", "谁"),
+  e("誰", "だれ", "dare", "pronoun", "who", "谁"),
+  e("どんな", "どんな", "donna", "prefix", "what kind of", "什么样的"),
+  e("どれ", "どれ", "dore", "pronoun", "which one", "哪个"),
+  e("いくら", "いくら", "ikura", "pronoun", "how much", "多少钱"),
+
+  // very common adverbs that appear as glue
+  e("もっと", "もっと", "motto", "adverb", "more", "更"),
+  e("一緒に", "いっしょに", "issho ni", "adverb", "together", "一起"),
+  e("とても", "とても", "totemo", "adverb", "very", "非常"),
+  e("よく", "よく", "yoku", "adverb", "often / well", "经常、好好地"),
+  e("たくさん", "たくさん", "takusan", "adverb", "a lot", "很多"),
+  e("ちょっと", "ちょっと", "chotto", "adverb", "a little", "稍微"),
+  e("まだ", "まだ", "mada", "adverb", "still / not yet", "还、尚未"),
+  e("もう", "もう", "mou", "adverb", "already", "已经"),
+];

--- a/playground/src/vocab/types.ts
+++ b/playground/src/vocab/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Vocabulary table schema. The dictionary is the single source of truth for how
+ * every word in the tutorial is read and what it means. A compiler check
+ * (scripts/verify-vocab.mjs) guarantees every word used in the course's Typed
+ * Japanese snippets indexes into this table.
+ */
+export type PartOfSpeech =
+  | "noun"
+  | "pronoun"
+  | "verb-godan"
+  | "verb-ichidan"
+  | "verb-irregular"
+  | "i-adjective"
+  | "na-adjective"
+  | "adverb"
+  | "particle"
+  | "copula"
+  | "conjunction"
+  | "interjection"
+  | "counter"
+  | "number"
+  | "expression"
+  | "suffix"
+  | "prefix";
+
+export interface VocabEntry {
+  /** Headword — the exact surface used in the tutorial (dictionary form). */
+  word: string;
+  /** Kana reading (hiragana/katakana). */
+  reading: string;
+  /** Hepburn romaji. */
+  romaji: string;
+  pos: PartOfSpeech;
+  en: string;
+  zh: string;
+}
+
+export const POS_LABEL: Record<PartOfSpeech, { en: string; zh: string }> = {
+  noun: { en: "noun", zh: "名词" },
+  pronoun: { en: "pronoun", zh: "代词" },
+  "verb-godan": { en: "godan verb", zh: "五段动词" },
+  "verb-ichidan": { en: "ichidan verb", zh: "一段动词" },
+  "verb-irregular": { en: "irregular verb", zh: "不规则动词" },
+  "i-adjective": { en: "i-adjective", zh: "い形容词" },
+  "na-adjective": { en: "na-adjective", zh: "な形容词" },
+  adverb: { en: "adverb", zh: "副词" },
+  particle: { en: "particle", zh: "助词" },
+  copula: { en: "copula", zh: "系动词" },
+  conjunction: { en: "conjunction", zh: "连词" },
+  interjection: { en: "interjection", zh: "感叹词" },
+  counter: { en: "counter", zh: "量词" },
+  number: { en: "number", zh: "数词" },
+  expression: { en: "expression", zh: "词组" },
+  suffix: { en: "suffix", zh: "后缀" },
+  prefix: { en: "prefix", zh: "前缀" },
+};


### PR DESCRIPTION
The course now has a **vocabulary table** so a learner can look up how to read any word.

## What's new

- **`src/vocab`** — a maintained dictionary: typed schema + a hand-written grammar-word table (particles, copula, suffixes, demonstratives, interrogatives) + **300 content-word entries** (nouns / verbs / adjectives) covering every word the course uses. Each entry has kanji, **kana reading**, romaji, part of speech, and **EN + 中文** meaning.
- **📚 Glossary tab** — searchable, POS-filterable table of all 372 words.
- **Click-to-read everywhere** — every course example lists its words as clickable chips → popover with reading + romaji + POS + bilingual meaning; the structure tree shows furigana + meaning inline.

## Compiler-checked indexing

- `scripts/extract-words.mjs` parses every example's Typed Japanese snippet with the **TypeScript compiler** and pulls out the content words.
- `scripts/verify-vocab.mjs` (`pnpm verify:vocab`) asserts every one of those words indexes into the table. **307/307 indexed** — so no word in the course can be un-lookup-able.

## Verification

`pnpm typecheck` + `pnpm build` pass. `verify:snippets` 382/382, `verify:vocab` 307/307. Headless-browser test: vocab popovers (`私 → わたし / watashi / I, me / 我`), glossary search (`たべ → 食べる`), tree readings, EN/中文 toggle, **zero console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)