### PR TITLE
fix: scrolling background seam + duplicate tab blossom

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌸</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>🌸 Typed Japanese Playground</title>
+    <title>Typed Japanese Playground</title>
     <script>
       // Resolve the theme before first paint so there is no light-mode flash.
       // Order: explicit stored choice, then OS preference.

--- a/playground/src/theme.css
+++ b/playground/src/theme.css
@@ -146,6 +146,10 @@ body {
     radial-gradient(1200px 500px at 100% -10%, var(--bg-glow-1), transparent 60%),
     radial-gradient(900px 500px at -10% 110%, var(--bg-glow-2), transparent 55%),
     var(--paper);
+  /* Anchor the glows to the viewport so they don't tile into a visible seam
+     every screen-height as the page scrolls. */
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   transition: background-color 0.2s ease, color 0.2s ease;
 }


### PR DESCRIPTION
Two small visual fixes reported after the sakura reskin:

1. **Scroll seam** — the playground body's radial-gradient glows used the default `background-repeat`, so they tiled into a slightly darker seam line every viewport-height on scroll. Now `no-repeat` + `background-attachment: fixed` anchors them to the viewport.
2. **Double blossom in the tab** — the favicon is already a 🌸 emoji; the `<title>` also led with 🌸, so the tab showed two. Removed it from the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)