### PR TITLE
chore: remove emoji from nav tab labels

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -84,19 +84,19 @@ export default function App() {
           className={`${styles.tab} ${tab === "tutorial" ? styles.tabActive : ""}`}
           onClick={() => setTab("tutorial")}
         >
-          📖 {t("Grammar Course", "语法教程")}
+          {t("Grammar Course", "语法教程")}
         </button>
         <button
           className={`${styles.tab} ${tab === "glossary" ? styles.tabActive : ""}`}
           onClick={() => setTab("glossary")}
         >
-          📚 {t("Glossary", "词汇表")}
+          {t("Glossary", "词汇表")}
         </button>
         <button
           className={`${styles.tab} ${tab === "playground" ? styles.tabActive : ""}`}
           onClick={() => setTab("playground")}
         >
-          🧪 {t("Playground", "演练场")}
+          {t("Playground", "演练场")}
         </button>
       </nav>
 


### PR DESCRIPTION
Removes the 📖 / 📚 / 🧪 emoji prefixes from the three nav tabs (语法教程 / 词汇表 / 演练场) for a cleaner look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)