### PR TITLE
feat: textbook fonts as default type

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -6,6 +6,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Typed Japanese Playground</title>
+    <!-- Tutorial type: textbook feel. Klee One for Japanese (教科書体),
+         LXGW WenKai Screen for Chinese prose (楷体). Both are unicode-range
+         split, so only the glyphs actually on screen get downloaded. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&family=Noto+Serif+JP:wght@400;600;700&family=Noto+Serif+SC:wght@400;600;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-screen-webfont/style.css"
+    />
     <script>
       // Resolve the theme before first paint so there is no light-mode flash.
       // Order: explicit stored choice, then OS preference.

--- a/playground/src/App.module.css
+++ b/playground/src/App.module.css
@@ -29,6 +29,7 @@
 
 .title {
   margin: 0;
+  font-family: var(--font-heading);
   font-size: 1.4rem;
   font-weight: 800;
   letter-spacing: -0.01em;

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Tutorial from "./components/Tutorial";
 import Playground from "./components/Playground";
 import Glossary from "./components/Glossary";
+import FontLab from "./components/FontLab";
 import { useLang } from "./context/lang";
 import { useTheme } from "./context/theme";
 import styles from "./App.module.css";
@@ -112,6 +113,8 @@ export default function App() {
           "所有活用变形都由 TypeScript 类型系统推导 —— 可被编译器验证的语法。"
         )}
       </footer>
+
+      {import.meta.env.DEV && <FontLab />}
     </div>
   );
 }

--- a/playground/src/components/FontLab.module.css
+++ b/playground/src/components/FontLab.module.css
@@ -1,0 +1,151 @@
+.fab {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 60;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--ink-700);
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 9px 14px;
+  border-radius: 999px;
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  transition: transform 0.12s, color 0.12s;
+}
+
+.fab:hover {
+  color: var(--sakura-600);
+  transform: translateY(-1px);
+}
+
+.panel {
+  position: fixed;
+  right: 18px;
+  bottom: 64px;
+  z-index: 60;
+  width: min(360px, calc(100vw - 36px));
+  max-height: min(72vh, 680px);
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-drawer);
+  overflow: hidden;
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.devTag {
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--on-accent);
+  background: var(--sakura-400);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+
+.close {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: var(--ink-500);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.close:hover {
+  color: var(--ink-900);
+}
+
+.hint {
+  margin: 0;
+  padding: 10px 14px;
+  font-size: 0.76rem;
+  color: var(--ink-500);
+  border-bottom: 1px solid var(--border);
+}
+
+.list {
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.preset {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.preset:hover {
+  border-color: var(--border-strong);
+}
+
+.presetActive {
+  border-color: var(--sakura-400);
+  background: var(--sakura-50);
+}
+
+.presetMeta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.presetName {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.presetNote {
+  font-size: 0.68rem;
+  color: var(--ink-500);
+  flex: none;
+}
+
+.swatch {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--border);
+}
+
+.swatchHeading {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.swatchBody {
+  font-size: 0.86rem;
+  color: var(--ink-700);
+}
+
+.swatchJp {
+  font-size: 1rem;
+  color: var(--sakura-600);
+}

--- a/playground/src/components/FontLab.tsx
+++ b/playground/src/components/FontLab.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from "react";
+import styles from "./FontLab.module.css";
+
+/**
+ * FontLab — a dev-only floating panel for trying out tutorial fonts.
+ *
+ * It overrides three CSS custom properties live on :root:
+ *   --font-ui      Latin + Chinese prose (the bulk of the explanation text)
+ *   --font-jp      Japanese example sentences / kana / kanji
+ *   --font-heading the big titles (app title, chapter title, point title)
+ *
+ * Each preset bundles a coordinated CN + JP + heading stack so switching gives
+ * a cohesive look rather than a Frankenstein mix. Mounted only when
+ * import.meta.env.DEV is true, so production never loads the web fonts.
+ */
+
+type Preset = {
+  id: string;
+  name: string;
+  note: string;
+  /** swatch: a short Japanese sample shown in --font-jp */
+  ui: string;
+  jp: string;
+  heading: string;
+};
+
+const PRESETS: Preset[] = [
+  {
+    id: "default",
+    name: "黑体 · 当前默认",
+    note: "无衬线 Gothic，技术文档感",
+    ui: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+    jp: '"Hiragino Kaku Gothic ProN", "Yu Gothic", "Noto Sans JP", sans-serif',
+    heading: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  },
+  {
+    id: "system-mincho",
+    name: "系统宋体／明朝",
+    note: "macOS 自带，无需联网",
+    ui: '"Songti SC", "STSong", "SimSun", serif',
+    jp: '"Hiragino Mincho ProN", "Yu Mincho", "YuMincho", "Noto Serif JP", serif',
+    heading: '"Songti SC", "Hiragino Mincho ProN", "Yu Mincho", serif',
+  },
+  {
+    id: "noto-serif",
+    name: "思源宋体 · Noto Serif",
+    note: "CN/JP 协调的经典衬线",
+    ui: '"Noto Serif SC", "Noto Serif JP", serif',
+    jp: '"Noto Serif JP", "Noto Serif SC", serif',
+    heading: '"Noto Serif JP", "Noto Serif SC", serif',
+  },
+  {
+    id: "shippori",
+    name: "しっぽり明朝 · Shippori",
+    note: "纤细优雅的日系明朝",
+    ui: '"Noto Serif SC", "Shippori Mincho", serif',
+    jp: '"Shippori Mincho", "Noto Serif JP", serif',
+    heading: '"Shippori Mincho", "Noto Serif SC", serif',
+  },
+  {
+    id: "zen-old",
+    name: "Zen Old Mincho",
+    note: "沉静古典，留白感强",
+    ui: '"Noto Serif SC", "Zen Old Mincho", serif',
+    jp: '"Zen Old Mincho", "Noto Serif JP", serif',
+    heading: '"Zen Old Mincho", "Noto Serif SC", serif',
+  },
+  {
+    id: "lxgw",
+    name: "霞鹜文楷 · LXGW WenKai",
+    note: "楷体，CN+JP 一体，最像课本",
+    ui: '"LXGW WenKai", "Noto Serif SC", serif',
+    jp: '"LXGW WenKai", "Noto Serif JP", serif',
+    heading: '"LXGW WenKai", serif',
+  },
+  {
+    id: "klee",
+    name: "Klee One · 教科書体",
+    note: "日本教科书手写感",
+    ui: '"LXGW WenKai", "Klee One", "Noto Serif SC", serif',
+    jp: '"Klee One", "LXGW WenKai", serif',
+    heading: '"Klee One", "LXGW WenKai", serif',
+  },
+  {
+    id: "zen-maru",
+    name: "Zen Maru Gothic · 圆体",
+    note: "圆润亲切，仍属黑体",
+    ui: '"Zen Maru Gothic", "PingFang SC", system-ui, sans-serif',
+    jp: '"Zen Maru Gothic", "Hiragino Maru Gothic ProN", sans-serif',
+    heading: '"Zen Maru Gothic", sans-serif',
+  },
+];
+
+// Web fonts pulled on demand (dev only). Google Fonts subsets CJK by
+// unicode-range, so only the glyphs in view get downloaded.
+const FONT_LINKS = [
+  "https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;600;700&family=Noto+Serif+JP:wght@400;600;700&family=Shippori+Mincho:wght@400;600;700&family=Zen+Old+Mincho:wght@400;600;700&family=Klee+One:wght@400;600&family=Zen+Maru+Gothic:wght@400;500;700&display=swap",
+  "https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css",
+];
+
+const STORAGE_KEY = "fontlab-preset";
+
+function applyPreset(p: Preset) {
+  const root = document.documentElement;
+  root.style.setProperty("--font-ui", p.ui);
+  root.style.setProperty("--font-jp", p.jp);
+  root.style.setProperty("--font-heading", p.heading);
+}
+
+function clearPreset() {
+  const root = document.documentElement;
+  root.style.removeProperty("--font-ui");
+  root.style.removeProperty("--font-jp");
+  root.style.removeProperty("--font-heading");
+}
+
+export default function FontLab() {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<string | null>(null);
+
+  // Inject the web-font stylesheets once.
+  useEffect(() => {
+    FONT_LINKS.forEach((href) => {
+      if (document.querySelector(`link[href="${href}"]`)) return;
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = href;
+      document.head.appendChild(link);
+    });
+  }, []);
+
+  // Restore last choice.
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    const p = PRESETS.find((x) => x.id === saved);
+    if (p) {
+      applyPreset(p);
+      setActive(p.id);
+    }
+  }, []);
+
+  function choose(p: Preset) {
+    if (p.id === "default") {
+      clearPreset();
+      localStorage.removeItem(STORAGE_KEY);
+      setActive(null);
+      return;
+    }
+    applyPreset(p);
+    localStorage.setItem(STORAGE_KEY, p.id);
+    setActive(p.id);
+  }
+
+  return (
+    <>
+      <button
+        className={styles.fab}
+        onClick={() => setOpen((o) => !o)}
+        title="字体实验室（仅本地开发可见）"
+      >
+        Aa 字体
+      </button>
+
+      {open && (
+        <div className={styles.panel}>
+          <div className={styles.head}>
+            <strong>字体实验室</strong>
+            <span className={styles.devTag}>DEV</span>
+            <button className={styles.close} onClick={() => setOpen(false)}>
+              ×
+            </button>
+          </div>
+          <p className={styles.hint}>
+            点击切换正文 / 日语 / 标题字体，效果即时生效，选择会被记住。
+          </p>
+          <div className={styles.list}>
+            {PRESETS.map((p) => {
+              const isActive =
+                active === p.id || (active === null && p.id === "default");
+              return (
+                <button
+                  key={p.id}
+                  className={`${styles.preset} ${isActive ? styles.presetActive : ""}`}
+                  onClick={() => choose(p)}
+                >
+                  <div className={styles.presetMeta}>
+                    <span className={styles.presetName}>{p.name}</span>
+                    <span className={styles.presetNote}>{p.note}</span>
+                  </div>
+                  <div className={styles.swatch}>
+                    <span
+                      className={styles.swatchHeading}
+                      style={{ fontFamily: p.heading }}
+                    >
+                      存在句：あります
+                    </span>
+                    <span
+                      className={styles.swatchBody}
+                      style={{ fontFamily: p.ui }}
+                    >
+                      想象你身处一个陌生的街区，
+                    </span>
+                    <span
+                      className={styles.swatchJp}
+                      style={{ fontFamily: p.jp }}
+                    >
+                      場所 に 事物 が あります。
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/playground/src/components/Tutorial.module.css
+++ b/playground/src/components/Tutorial.module.css
@@ -102,6 +102,7 @@
 
 .chapterTitle {
   margin: 4px 0 6px;
+  font-family: var(--font-heading);
   font-size: 1.7rem;
   font-weight: 800;
   color: var(--ink-900);
@@ -122,6 +123,7 @@
 
 .pointTitle {
   margin: 0 0 8px;
+  font-family: var(--font-heading);
   font-size: 1.2rem;
   font-weight: 700;
   color: var(--sakura-600);

--- a/playground/src/theme.css
+++ b/playground/src/theme.css
@@ -69,8 +69,12 @@
   --bg-glow-1: rgba(251, 227, 234, 0.9);
   --bg-glow-2: rgba(244, 198, 212, 0.55);
 
-  --font-jp: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Noto Sans JP", sans-serif;
-  --font-ui: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  /* Textbook type. Japanese in Klee One (教科書体); Chinese/Latin prose in
+     LXGW WenKai (霞鹜文楷, 楷体) — warmer and more "course-like" than the old
+     gothic. Loaded in index.html; gracefully falls back to system mincho. */
+  --font-jp: "Klee One", "LXGW WenKai Screen", "Hiragino Mincho ProN", serif;
+  --font-ui: "LXGW WenKai Screen", "Klee One", "Noto Serif SC", "Songti SC", serif;
+  --font-heading: "Klee One", "LXGW WenKai Screen", "Noto Serif SC", serif;
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 }
 


### PR DESCRIPTION
把教程的默认字体从黑体/无衬线换成更有「课本感」的字体组合：

- **日语**：Klee One（教科書体）
- **中文／西文正文**：LXGW WenKai 霞鹜文楷（楷体）
- **标题**：新增 `--font-heading` 变量，应用于 App 标题、章节标题、知识点标题
- 系统宋体/明朝作为 fallback

字体通过 `index.html` 引入，使用 **unicode-range 切分**的 webfont（Google Fonts + lxgw-wenkai-screen-webfont），只有屏幕上实际出现的字形才会下载，避免一次性拉取整套 CJK 字体。

另外附带 `FontLab` —— 一个**仅本地开发可见**（`import.meta.env.DEV`）的浮动面板，可现场切换多套字体预设对比。已确认它**不会进入生产构建**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)