### PR TITLE
feat: default to LXGW WenKai (霞鹜文楷)

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -6,15 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Typed Japanese Playground</title>
-    <!-- Tutorial type: textbook feel. Klee One for Japanese (教科書体),
-         LXGW WenKai Screen for Chinese prose (楷体). Both are unicode-range
-         split, so only the glyphs actually on screen get downloaded. -->
+    <!-- Tutorial type: textbook feel in LXGW WenKai Screen (霞鹜文楷, 楷体),
+         which covers CN + JP. Noto Serif SC/JP are the fallbacks. The webfont
+         is unicode-range split, so only the glyphs on screen get downloaded. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&family=Noto+Serif+JP:wght@400;600;700&family=Noto+Serif+SC:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600;700&family=Noto+Serif+SC:wght@400;600;700&display=swap"
     />
     <link
       rel="stylesheet"

--- a/playground/src/components/FontLab.module.css
+++ b/playground/src/components/FontLab.module.css
@@ -44,6 +44,16 @@
   border-bottom: 1px solid var(--border);
 }
 
+.devTag {
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--on-accent);
+  background: var(--sakura-400);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+
 .close {
   margin-left: auto;
   border: none;
@@ -57,14 +67,6 @@
 
 .close:hover {
   color: var(--ink-900);
-}
-
-.hint {
-  margin: 0;
-  padding: 10px 14px;
-  font-size: 0.76rem;
-  color: var(--ink-500);
-  border-bottom: 1px solid var(--border);
 }
 
 .list {

--- a/playground/src/components/FontLab.tsx
+++ b/playground/src/components/FontLab.tsx
@@ -68,7 +68,7 @@ const PRESETS: Preset[] = [
   {
     id: "lxgw",
     name: "霞鹜文楷 · LXGW WenKai",
-    note: "楷体，CN+JP 一体，最像课本",
+    note: "当前默认 · 楷体，CN+JP 一体",
     ui: '"LXGW WenKai Screen", "Noto Serif SC", serif',
     jp: '"LXGW WenKai Screen", "Noto Serif JP", serif',
     heading: '"LXGW WenKai Screen", serif',
@@ -76,7 +76,7 @@ const PRESETS: Preset[] = [
   {
     id: "klee",
     name: "Klee One · 教科書体",
-    note: "当前默认 · 教科书手写感",
+    note: "日本教科书手写感",
     ui: '"LXGW WenKai Screen", "Klee One", "Noto Serif SC", serif',
     jp: '"Klee One", "LXGW WenKai Screen", serif',
     heading: '"Klee One", "LXGW WenKai Screen", serif',
@@ -97,7 +97,7 @@ const PRESETS: Preset[] = [
 // they never weigh on normal page load. Google Fonts subsets CJK by
 // unicode-range, so only the glyphs in view get downloaded.
 const FONT_LINKS = [
-  "https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@400;600;700&family=Zen+Old+Mincho:wght@400;600;700&family=Zen+Maru+Gothic:wght@400;500;700&display=swap",
+  "https://fonts.googleapis.com/css2?family=Klee+One:wght@400;600&family=Shippori+Mincho:wght@400;600;700&family=Zen+Old+Mincho:wght@400;600;700&family=Zen+Maru+Gothic:wght@400;500;700&display=swap",
 ];
 
 const STORAGE_KEY = "fontlab-preset";
@@ -109,35 +109,41 @@ function applyPreset(p: Preset) {
   root.style.setProperty("--font-heading", p.heading);
 }
 
-// The live default (see theme.css) is the textbook stack — i.e. the "klee"
-// preset. With no stored override that is what the page already renders.
-const DEFAULT_ID = "klee";
+// The live default (see theme.css) is the LXGW WenKai stack — i.e. the
+// "lxgw" preset. With no stored override that is what the page renders, and
+// its webfont is loaded eagerly in index.html.
+const DEFAULT_ID = "lxgw";
+
+// Pull the extra preview fonts (everything except the eagerly-loaded
+// default). Idempotent — the querySelector guard dedupes.
+function injectFonts() {
+  FONT_LINKS.forEach((href) => {
+    if (document.querySelector(`link[href="${href}"]`)) return;
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+  });
+}
 
 export default function FontLab() {
   const [open, setOpen] = useState(false);
   const [active, setActive] = useState<string>(DEFAULT_ID);
-  const [fontsInjected, setFontsInjected] = useState(false);
 
-  // Lazily inject the extra preview fonts the first time the panel opens, so
-  // visitors who never touch the switcher pay nothing for them.
+  // Inject the preview fonts the first time the panel opens, so visitors who
+  // never touch the switcher pay nothing for them.
   useEffect(() => {
-    if (!open || fontsInjected) return;
-    FONT_LINKS.forEach((href) => {
-      if (document.querySelector(`link[href="${href}"]`)) return;
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.href = href;
-      document.head.appendChild(link);
-    });
-    setFontsInjected(true);
-  }, [open, fontsInjected]);
+    if (open) injectFonts();
+  }, [open]);
 
-  // Restore last choice.
+  // Restore last choice — and load its font too, since the selection is
+  // applied before the panel is ever opened.
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (!saved) return;
     const p = PRESETS.find((x) => x.id === saved);
     if (p) {
+      if (p.id !== DEFAULT_ID) injectFonts();
       applyPreset(p);
       setActive(p.id);
     }
@@ -163,13 +169,11 @@ export default function FontLab() {
         <div className={styles.panel}>
           <div className={styles.head}>
             <strong>切换字体</strong>
+            <span className={styles.devTag}>DEV</span>
             <button className={styles.close} onClick={() => setOpen(false)}>
               ×
             </button>
           </div>
-          <p className={styles.hint}>
-            点击切换正文 / 日语 / 标题字体，效果即时生效，选择会被记住。
-          </p>
           <div className={styles.list}>
             {PRESETS.map((p) => {
               const isActive = active === p.id;

--- a/playground/src/theme.css
+++ b/playground/src/theme.css
@@ -69,12 +69,12 @@
   --bg-glow-1: rgba(251, 227, 234, 0.9);
   --bg-glow-2: rgba(244, 198, 212, 0.55);
 
-  /* Textbook type. Japanese in Klee One (教科書体); Chinese/Latin prose in
-     LXGW WenKai (霞鹜文楷, 楷体) — warmer and more "course-like" than the old
-     gothic. Loaded in index.html; gracefully falls back to system mincho. */
-  --font-jp: "Klee One", "LXGW WenKai Screen", "Hiragino Mincho ProN", serif;
-  --font-ui: "LXGW WenKai Screen", "Klee One", "Noto Serif SC", "Songti SC", serif;
-  --font-heading: "Klee One", "LXGW WenKai Screen", "Noto Serif SC", serif;
+  /* Textbook type. LXGW WenKai (霞鹜文楷, 楷体) everywhere — it covers CN +
+     JP (kana/kanji) in one warm, course-like kaishu. Loaded in index.html;
+     gracefully falls back to Noto Serif / system mincho. */
+  --font-jp: "LXGW WenKai Screen", "Noto Serif JP", "Hiragino Mincho ProN", serif;
+  --font-ui: "LXGW WenKai Screen", "Noto Serif SC", "Songti SC", serif;
+  --font-heading: "LXGW WenKai Screen", "Noto Serif SC", serif;
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 }
 


### PR DESCRIPTION
把整个教程的默认字体改成 **霞鹜文楷 LXGW WenKai**(楷体)—— 一套字体同时覆盖中文与日语(假名/汉字),比 Klee+楷体的组合更统一。

- 默认栈改为 `LXGW WenKai Screen`(unicode-range 切分版,按需下载字形),fallback 为 Noto Serif SC/JP、系统明朝。
- Klee One 不再随首屏加载,移入字体面板的懒加载预览集。
- 修了一个隐患:之前若用户选过非默认字体,刷新后在打开面板前会短暂回退到 fallback(因为选择在面板打开前就已套用,但字体还没注入)。现在恢复选择时会一并注入其字体。
- 面板标题加回 `DEV` 角标表明这是开发向功能;删掉啰嗦的提示行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)