### PR TITLE
fix: shorten header tagline to one line

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -23,8 +23,8 @@ export default function App() {
             <h1 className={styles.title}>Typed Japanese</h1>
             <p className={styles.tagline}>
               {t(
-                "Learn Japanese grammar — every sentence is a type the compiler can read.",
-                "用 TypeScript 学日语语法 —— 每个句子都是编译器能读懂的类型。"
+                "Learn Japanese grammar as TypeScript types.",
+                "用 TypeScript 类型学日语语法。"
               )}
             </p>
           </div>


### PR DESCRIPTION
原来的副标题英文折成两行、中文一行,切换语言时布局会跳动。两边都精简成一句单行:

- EN: `Learn Japanese grammar as TypeScript types.`
- 中文:`用 TypeScript 类型学日语语法。`

🤖 Generated with [Claude Code](https://claude.com/claude-code)