### PR TITLE
feat: native routing + a rewritten, diagram-rich Foundations primer

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import Concepts from "./components/Concepts";
 import Tutorial from "./components/Tutorial";
 import Playground from "./components/Playground";
@@ -6,31 +5,14 @@ import Glossary from "./components/Glossary";
 import FontLab from "./components/FontLab";
 import { useLang } from "./context/lang";
 import { useTheme } from "./context/theme";
+import { useRoute } from "./context/route";
 import styles from "./App.module.css";
-
-type Tab = "concepts" | "tutorial" | "glossary" | "playground";
 
 export default function App() {
   const { lang, setLang, t } = useLang();
   const { theme, toggleTheme } = useTheme();
-  const [tab, setTab] = useState<Tab>("concepts");
-  // A glossary "used in" link requesting a jump to a specific example.
-  const [jump, setJump] = useState<{ chapterId: string; anchor: string } | null>(
-    null
-  );
-  // A Foundations article can deep-link into a Course chapter; this carries the
-  // requested chapter id across the tab switch into <Tutorial>.
-  const [focusChapter, setFocusChapter] = useState<string | null>(null);
-
-  const navigateToExample = (chapterId: string, anchor: string) => {
-    setJump({ chapterId, anchor });
-    setTab("tutorial");
-  };
-
-  const openChapter = (id: string) => {
-    setFocusChapter(id);
-    setTab("tutorial");
-  };
+  const { route, navigate } = useRoute();
+  const tab = route.tab;
 
   return (
     <div className={styles.app}>
@@ -104,41 +86,34 @@ export default function App() {
       <nav className={styles.tabs}>
         <button
           className={`${styles.tab} ${tab === "concepts" ? styles.tabActive : ""}`}
-          onClick={() => setTab("concepts")}
+          onClick={() => navigate({ tab: "concepts" })}
         >
-          🏛️ {t("Foundations", "原理")}
+          {t("Foundations", "原理")}
         </button>
         <button
           className={`${styles.tab} ${tab === "tutorial" ? styles.tabActive : ""}`}
-          onClick={() => setTab("tutorial")}
+          onClick={() => navigate({ tab: "tutorial" })}
         >
           {t("Grammar Course", "语法教程")}
         </button>
         <button
           className={`${styles.tab} ${tab === "glossary" ? styles.tabActive : ""}`}
-          onClick={() => setTab("glossary")}
+          onClick={() => navigate({ tab: "glossary" })}
         >
           {t("Glossary", "词汇表")}
         </button>
         <button
           className={`${styles.tab} ${tab === "playground" ? styles.tabActive : ""}`}
-          onClick={() => setTab("playground")}
+          onClick={() => navigate({ tab: "playground" })}
         >
           {t("Playground", "演练场")}
         </button>
       </nav>
 
       <main className={styles.main}>
-        {tab === "concepts" && <Concepts onOpenChapter={openChapter} />}
-        {tab === "tutorial" && (
-          <Tutorial
-            jump={jump}
-            onJumpHandled={() => setJump(null)}
-            focusChapter={focusChapter}
-            onChapterFocused={() => setFocusChapter(null)}
-          />
-        )}
-        {tab === "glossary" && <Glossary onNavigate={navigateToExample} />}
+        {tab === "concepts" && <Concepts />}
+        {tab === "tutorial" && <Tutorial />}
+        {tab === "glossary" && <Glossary />}
         {tab === "playground" && <Playground />}
       </main>
 

--- a/playground/src/components/Concepts.module.css
+++ b/playground/src/components/Concepts.module.css
@@ -53,27 +53,10 @@
   color: var(--sakura-600);
 }
 
-.articleIcon {
-  font-size: 1.3rem;
-  flex: none;
-}
-
-.articleLinkText {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-}
-
 .articleLinkTitle {
   font-size: 0.9rem;
   font-weight: 700;
   line-height: 1.25;
-}
-
-.articleLinkRead {
-  font-size: 0.72rem;
-  color: var(--ink-300);
 }
 
 /* ---- article content ---- */
@@ -86,23 +69,12 @@
   margin-bottom: 8px;
 }
 
-.readChip {
-  margin-bottom: 10px;
-}
-
 .articleTitle {
   margin: 4px 0 8px;
   font-size: 1.9rem;
   font-weight: 800;
   color: var(--ink-900);
   line-height: 1.2;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.articleTitleIcon {
-  font-size: 1.7rem;
 }
 
 .articleTagline {
@@ -216,6 +188,262 @@
   line-height: 1.65;
   color: var(--ink-700);
   font-size: 0.95rem;
+}
+
+/* ---- compare card: Japanese ↔ English ↔ TypeScript ---- */
+.compare {
+  max-width: 72ch;
+  margin: 16px 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.compareJpRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  padding: 12px 16px 8px;
+}
+
+.compareJp {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.compareReading {
+  font-size: 0.9rem;
+  color: var(--ink-500);
+}
+
+.compareGloss {
+  padding: 0 16px 12px;
+  font-size: 0.95rem;
+  color: var(--ink-500);
+  border-bottom: 1px solid var(--border);
+}
+
+.compareTs {
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--code-bg);
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: var(--ink-700);
+  overflow-x: auto;
+  white-space: pre;
+  tab-size: 2;
+}
+
+/* syntax-highlight tokens */
+.tokComment {
+  color: var(--ink-500);
+  font-style: italic;
+}
+.tokString {
+  color: var(--cat-noun);
+}
+.tokKeyword {
+  color: var(--cat-particle);
+  font-weight: 600;
+}
+.tokType {
+  color: var(--cat-verb);
+}
+.tokFunc {
+  color: var(--cat-phrase);
+}
+.tokNumber {
+  color: var(--cat-conjugation);
+}
+.tokPunct {
+  color: var(--ink-500);
+}
+
+.compareNote {
+  margin: 0;
+  padding: 11px 16px 13px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--ink-700);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
+}
+
+/* ---- composition diagram: nested clauses as boxes ---- */
+.diagram {
+  max-width: 72ch;
+  margin: 16px 0;
+  padding: 16px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.diaCaption {
+  font-size: 0.9rem;
+  color: var(--ink-500);
+  line-height: 1.55;
+  margin-bottom: 12px;
+}
+
+.diaCanvas {
+  overflow-x: auto;
+}
+
+/* a clause = a bordered box whose contents are args → verb */
+.diaClause {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+
+/* nested clauses get the paper tone so depth reads through alternation */
+.diaClause .diaClause {
+  background: var(--code-bg);
+}
+
+.diaClauseLabel {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--sakura-600);
+}
+
+.diaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.diaChip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.diaArg .diaChipMain,
+.diaChipMain {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+  padding: 5px 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.diaWord {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ink-900);
+}
+
+.diaTag {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--sakura-600);
+}
+
+.diaRole {
+  font-size: 0.7rem;
+  color: var(--ink-500);
+  text-align: center;
+}
+
+.diaArrow {
+  font-family: var(--font-mono);
+  color: var(--ink-300);
+  font-weight: 700;
+}
+
+/* the verb — the function that closes the clause — stands out */
+.diaVerb {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--sakura-500);
+}
+
+.diaVerb .diaWord {
+  color: var(--on-accent);
+}
+
+/* ---- breakdown: peel a complex sentence apart ---- */
+.breakdown {
+  max-width: 72ch;
+  margin: 16px 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.breakdownHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  padding: 14px 16px;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+
+.breakdownJp {
+  font-size: 1.45rem;
+  font-weight: 800;
+  color: var(--ink-900);
+}
+
+.breakdownReading {
+  font-size: 0.9rem;
+  color: var(--ink-500);
+}
+
+.breakdownGloss {
+  flex-basis: 100%;
+  font-size: 0.92rem;
+  color: var(--ink-500);
+  line-height: 1.5;
+}
+
+.breakdownLayers {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+}
+
+.breakdownLayer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 12px;
+  padding: 7px 16px;
+  border-left: 2px solid var(--border-strong);
+  margin: 2px 0;
+}
+
+.breakdownFragment {
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: var(--sakura-600);
+  min-width: 8ch;
+}
+
+.breakdownRole {
+  font-size: 0.9rem;
+  color: var(--ink-700);
+  line-height: 1.5;
 }
 
 /* ---- example line ---- */

--- a/playground/src/components/Concepts.tsx
+++ b/playground/src/components/Concepts.tsx
@@ -1,9 +1,14 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { ARTICLES } from "../concepts";
-import type { ConceptArticle, ConceptBlock } from "../concepts/types";
+import type {
+  ConceptArticle,
+  ConceptBlock,
+  DiagramNode,
+} from "../concepts/types";
 import { CHAPTERS } from "../tutorial/chapters";
 import { LEVEL_META } from "../tutorial/levels";
 import { useLang } from "../context/lang";
+import { useRoute } from "../context/route";
 import styles from "./Concepts.module.css";
 
 /** Render a run of paragraphs with inline `code` and **bold** spans. */
@@ -36,13 +41,105 @@ function renderInline(text: string): ReactNode[] {
   });
 }
 
-export default function Concepts({
-  onOpenChapter,
-}: {
-  onOpenChapter: (id: string) => void;
-}) {
-  const { t } = useLang();
-  const [activeId, setActiveId] = useState<string>(ARTICLES[0]?.id ?? "");
+// --- tiny TypeScript/JS highlighter -----------------------------------------
+// The snippets are deliberately simple (comments, strings, a few keywords), so a
+// small left-to-right scanner is enough — no dependency. Japanese only ever
+// appears inside strings or comments, which are matched before anything else.
+const KEYWORDS = new Set([
+  "const", "let", "type", "interface", "extends", "return", "import", "from",
+  "as", "true", "false", "null",
+]);
+
+function classifyWord(
+  word: string,
+  nextNonSpace: string
+): string | null | undefined {
+  if (KEYWORDS.has(word)) return styles.tokKeyword;
+  if (/^[A-Z]/.test(word)) return styles.tokType;
+  if (nextNonSpace === "(") return styles.tokFunc;
+  return null;
+}
+
+function highlightLine(line: string, lineKey: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let i = 0;
+  let n = 0;
+  const push = (cls: string | null | undefined, text: string) =>
+    out.push(
+      cls ? (
+        <span key={`${lineKey}-${n++}`} className={cls}>
+          {text}
+        </span>
+      ) : (
+        <span key={`${lineKey}-${n++}`}>{text}</span>
+      )
+    );
+
+  while (i < line.length) {
+    const rest = line.slice(i);
+    if (rest.startsWith("//")) {
+      push(styles.tokComment, rest);
+      break;
+    }
+    if (line[i] === '"') {
+      let j = i + 1;
+      while (j < line.length && line[j] !== '"') j++;
+      push(styles.tokString, line.slice(i, Math.min(j + 1, line.length)));
+      i = j + 1;
+      continue;
+    }
+    const word = /^[A-Za-z_$][\w$]*/.exec(rest);
+    if (word) {
+      const w = word[0];
+      let k = i + w.length;
+      while (k < line.length && line[k] === " ") k++;
+      push(classifyWord(w, line[k] ?? ""), w);
+      i += w.length;
+      continue;
+    }
+    const num = /^\d+/.exec(rest);
+    if (num) {
+      push(styles.tokNumber, num[0]);
+      i += num[0].length;
+      continue;
+    }
+    const space = /^\s+/.exec(rest);
+    if (space) {
+      push(null, space[0]);
+      i += space[0].length;
+      continue;
+    }
+    const punct = /^[^\w\s"]+/.exec(rest);
+    if (punct) {
+      push(styles.tokPunct, punct[0]);
+      i += punct[0].length;
+      continue;
+    }
+    push(null, line[i] ?? "");
+    i += 1;
+  }
+  return out;
+}
+
+function CodeBlock({ code }: { code: string }): ReactNode {
+  const lines = code.split("\n");
+  return (
+    <pre className={styles.compareTs}>
+      <code>
+        {lines.map((ln, idx) => (
+          <span key={idx}>
+            {highlightLine(ln, String(idx))}
+            {idx < lines.length - 1 ? "\n" : null}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
+export default function Concepts() {
+  const { lang, t } = useLang();
+  const { route, navigate } = useRoute();
 
   const chapterById = useMemo(
     () => new Map(CHAPTERS.map((c) => [c.id, c])),
@@ -50,8 +147,9 @@ export default function Concepts({
   );
 
   const active = useMemo(
-    () => ARTICLES.find((a) => a.id === activeId) ?? ARTICLES[0] ?? null,
-    [activeId]
+    () =>
+      ARTICLES.find((a) => a.id === route.article) ?? ARTICLES[0] ?? null,
+    [route.article]
   );
 
   if (ARTICLES.length === 0) {
@@ -75,7 +173,7 @@ export default function Concepts({
               key={c.id}
               type="button"
               className={styles.chapterChip}
-              onClick={() => onOpenChapter(c.id)}
+              onClick={() => navigate({ tab: "tutorial", chapter: c.id })}
               title={t("Open this chapter", "打开该章节")}
             >
               <span className={styles.chapterChipEmoji}>
@@ -87,6 +185,38 @@ export default function Concepts({
           ))}
         </div>
       </div>
+    );
+  }
+
+  /** Recursively render a composition diagram node (clause = box, leaf = chip). */
+  function renderDia(node: DiagramNode, key: string): ReactNode {
+    const role =
+      node.roleEn || node.roleZh
+        ? t(node.roleEn ?? "", node.roleZh ?? "")
+        : null;
+    if (node.args && node.args.length) {
+      return (
+        <div key={key} className={styles.diaClause}>
+          {role && <span className={styles.diaClauseLabel}>{role}</span>}
+          <div className={styles.diaRow}>
+            {node.args.map((a, i) => renderDia(a, `${key}.${i}`))}
+            <span className={styles.diaArrow}>→</span>
+            <span className={`${styles.diaChip} ${styles.diaVerb}`}>
+              <span className={`jp ${styles.diaWord}`}>{node.label}</span>
+            </span>
+            {node.tag && <span className={`jp ${styles.diaTag}`}>{node.tag}</span>}
+          </div>
+        </div>
+      );
+    }
+    return (
+      <span key={key} className={`${styles.diaChip} ${styles.diaArg}`}>
+        <span className={styles.diaChipMain}>
+          <span className={`jp ${styles.diaWord}`}>{node.label}</span>
+          {node.tag && <span className={`jp ${styles.diaTag}`}>{node.tag}</span>}
+        </span>
+        {role && <span className={styles.diaRole}>{role}</span>}
+      </span>
     );
   }
 
@@ -111,6 +241,56 @@ export default function Concepts({
             <p className={styles.defineBody}>{renderInline(t(block.en, block.zh))}</p>
           </div>
         );
+      case "compare":
+        return (
+          <div className={styles.compare}>
+            <div className={styles.compareJpRow}>
+              <span className={`jp ${styles.compareJp}`}>{block.jp}</span>
+              {block.reading && (
+                <span className={`jp ${styles.compareReading}`}>
+                  {block.reading}
+                </span>
+              )}
+            </div>
+            <div className={styles.compareGloss}>{t(block.en, block.zh)}</div>
+            <CodeBlock code={lang === "zh" ? block.tsZh : block.tsEn} />
+            {(block.noteEn || block.noteZh) && (
+              <p className={styles.compareNote}>
+                {renderInline(t(block.noteEn ?? "", block.noteZh ?? ""))}
+              </p>
+            )}
+          </div>
+        );
+      case "breakdown":
+        return (
+          <div className={styles.breakdown}>
+            <div className={styles.breakdownHead}>
+              <span className={`jp ${styles.breakdownJp}`}>{block.jp}</span>
+              {block.reading && (
+                <span className={`jp ${styles.breakdownReading}`}>
+                  {block.reading}
+                </span>
+              )}
+              <span className={styles.breakdownGloss}>{t(block.en, block.zh)}</span>
+            </div>
+            <div className={styles.breakdownLayers}>
+              {block.layers.map((ly, k) => (
+                <div
+                  key={k}
+                  className={styles.breakdownLayer}
+                  style={{ marginLeft: `${(ly.depth ?? 0) * 22}px` }}
+                >
+                  <span className={`jp ${styles.breakdownFragment}`}>
+                    {ly.fragment}
+                  </span>
+                  <span className={styles.breakdownRole}>
+                    {renderInline(t(ly.en, ly.zh))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
       case "example":
         return (
           <div className={styles.example}>
@@ -123,6 +303,25 @@ export default function Concepts({
             <span className={styles.exampleGloss}>
               {renderInline(t(block.en, block.zh))}
             </span>
+          </div>
+        );
+      case "diagram":
+        return (
+          <div className={styles.diagram}>
+            {(block.captionEn || block.captionZh) && (
+              <div className={styles.diaCaption}>
+                {renderInline(t(block.captionEn ?? "", block.captionZh ?? ""))}
+              </div>
+            )}
+            <div className={styles.diaCanvas}>
+              {block.row ? (
+                <div className={styles.diaRow}>
+                  {block.row.map((n, i) => renderDia(n, `d${i}`))}
+                </div>
+              ) : block.root ? (
+                renderDia(block.root, "d")
+              ) : null}
+            </div>
           </div>
         );
       case "chapters":
@@ -140,17 +339,11 @@ export default function Concepts({
             <button
               key={a.id}
               type="button"
-              className={`${styles.articleLink} ${a.id === activeId ? styles.articleActive : ""}`}
-              onClick={() => setActiveId(a.id)}
+              className={`${styles.articleLink} ${a.id === active?.id ? styles.articleActive : ""}`}
+              onClick={() => navigate({ article: a.id })}
             >
-              <span className={styles.articleIcon}>{a.icon}</span>
-              <span className={styles.articleLinkText}>
-                <span className={styles.articleLinkTitle}>
-                  {t(a.titleEn, a.titleZh)}
-                </span>
-                <span className={styles.articleLinkRead}>
-                  {t(a.readEn, a.readZh)}
-                </span>
+              <span className={styles.articleLinkTitle}>
+                {t(a.titleEn, a.titleZh)}
               </span>
             </button>
           ))}
@@ -162,11 +355,7 @@ export default function Concepts({
         {active && (
           <>
             <header className={styles.articleHead}>
-              <span className={`tj-chip ${styles.readChip}`}>
-                ⏱ {t(active.readEn, active.readZh)}
-              </span>
               <h2 className={styles.articleTitle}>
-                <span className={styles.articleTitleIcon}>{active.icon}</span>
                 {t(active.titleEn, active.titleZh)}
               </h2>
               <p className={styles.articleTagline}>

--- a/playground/src/components/Glossary.tsx
+++ b/playground/src/components/Glossary.tsx
@@ -3,6 +3,7 @@ import { VOCAB_LIST } from "../vocab/dictionary";
 import { POS_LABEL, type PartOfSpeech } from "../vocab/types";
 import { REVERSE_INDEX } from "../tutorial/reverseIndex.generated";
 import { useLang } from "../context/lang";
+import { useRoute } from "../context/route";
 import styles from "./Glossary.module.css";
 
 const POS_GROUPS: { key: PartOfSpeech[]; en: string; zh: string }[] = [
@@ -13,13 +14,9 @@ const POS_GROUPS: { key: PartOfSpeech[]; en: string; zh: string }[] = [
   { key: ["particle", "copula", "suffix", "conjunction", "prefix"], en: "Grammar", zh: "语法词" },
 ];
 
-type Props = {
-  /** Jump to an example card in the tutorial tab. */
-  onNavigate: (chapterId: string, anchor: string) => void;
-};
-
-export default function Glossary({ onNavigate }: Props) {
+export default function Glossary() {
   const { lang, t } = useLang();
+  const { navigate } = useRoute();
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<number | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
@@ -126,7 +123,13 @@ export default function Glossary({ onNavigate }: Props) {
                               key={k}
                               type="button"
                               className={styles.refItem}
-                              onClick={() => onNavigate(r.chapterId, r.anchor)}
+                              onClick={() =>
+                                navigate({
+                                  tab: "tutorial",
+                                  chapter: r.chapterId,
+                                  ex: r.anchor,
+                                })
+                              }
                               title={t("Open in the course", "在教程中打开")}
                             >
                               <span className={`jp ${styles.refJp}`}>{r.jp}</span>

--- a/playground/src/components/Tutorial.tsx
+++ b/playground/src/components/Tutorial.tsx
@@ -10,6 +10,7 @@ import { CHAPTERS } from "../tutorial/chapters";
 import { LEVEL_META } from "../tutorial/levels";
 import { exampleAnchorId, type Chapter, type Example, type Level } from "../tutorial/types";
 import { useLang } from "../context/lang";
+import { useRoute } from "../context/route";
 import { extractWords } from "../vocab/extract";
 import Analyzer from "./Analyzer";
 import VocabWord from "./VocabWord";
@@ -38,38 +39,28 @@ function RichText({ text }: { text: string }): ReactNode {
   );
 }
 
-type Props = {
-  /** A glossary "used in" link requesting a jump to an example. */
-  jump: { chapterId: string; anchor: string } | null;
-  onJumpHandled: () => void;
-  /** When set (e.g. from a Foundations deep-link), jump to this chapter id. */
-  focusChapter?: string | null;
-  onChapterFocused?: () => void;
-};
-
-export default function Tutorial({
-  jump,
-  onJumpHandled,
-  focusChapter = null,
-  onChapterFocused,
-}: Props) {
+export default function Tutorial() {
   const { lang, t } = useLang();
+  const { route, navigate } = useRoute();
   const [query, setQuery] = useState("");
-  const [activeId, setActiveId] = useState<string>(
-    jump?.chapterId ?? CHAPTERS[0]?.id ?? ""
-  );
+  // The selected chapter is driven by the URL, so Back / Forward move between
+  // chapters and a deep-link (Foundations / Glossary) lands on the right one.
+  const activeId =
+    route.chapter && CHAPTERS.some((c) => c.id === route.chapter)
+      ? route.chapter
+      : CHAPTERS[0]?.id ?? "";
   const [drawerExample, setDrawerExample] = useState<Example | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [flash, setFlash] = useState<string | null>(null);
   const pendingAnchor = useRef<string | null>(null);
 
-  // A jump request: select the chapter, then mark the anchor for scrolling.
+  // The route can point at an example (a Glossary "used in" link). Capture the
+  // anchor, then strip it from the URL so re-clicking the same link re-fires.
   useEffect(() => {
-    if (!jump) return;
-    pendingAnchor.current = jump.anchor;
-    setActiveId(jump.chapterId);
-    onJumpHandled();
-  }, [jump, onJumpHandled]);
+    if (!route.ex) return;
+    pendingAnchor.current = route.ex;
+    navigate({ ex: undefined }, { replace: true });
+  }, [route.ex, navigate]);
 
   // After the target chapter has rendered, scroll the example into view and
   // flash it. Runs after every render until the anchor element exists.
@@ -87,14 +78,6 @@ export default function Tutorial({
     );
     return () => window.clearTimeout(timer);
   });
-
-  // Honour a deep-link from another tab: select the requested chapter once.
-  useEffect(() => {
-    if (focusChapter && CHAPTERS.some((c) => c.id === focusChapter)) {
-      setActiveId(focusChapter);
-      onChapterFocused?.();
-    }
-  }, [focusChapter, onChapterFocused]);
 
   const byLevel = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -153,7 +136,7 @@ export default function Tutorial({
                     key={c.id}
                     type="button"
                     className={`${styles.chapterLink} ${c.id === activeId ? styles.chapterActive : ""}`}
-                    onClick={() => setActiveId(c.id)}
+                    onClick={() => navigate({ chapter: c.id })}
                   >
                     <span className={styles.chapterNum}>{c.order}</span>
                     <span>{t(c.titleEn, c.titleZh)}</span>

--- a/playground/src/concepts/articles/architecture.ts
+++ b/playground/src/concepts/articles/architecture.ts
@@ -1,199 +1,606 @@
 import type { ConceptArticle } from "../types";
 
 /**
- * The flagship Foundations article: the architecture of Japanese for someone who
- * thinks in systems, in ~1 hour. Defines every piece of jargon (体言/用言/助詞/
- * 活用/コピュラ) inline and indexes into the Course chapters.
+ * The flagship Foundations article. Method: teach each structural idea by
+ * showing one thought three ways — Japanese, English, and a small piece of
+ * lightweight TypeScript (comments in the reader's language, syntax-highlighted)
+ * — and define every jargon term inline. The spine is the function idea: a
+ * clause is a verb (function) applied to tagged arguments, with the verb last,
+ * and sentences nest those calls.
  */
 const article: ConceptArticle = {
   id: "architecture",
   order: 1,
-  icon: "🏛️",
-  titleEn: "Japanese in One Hour: the Architecture",
-  titleZh: "一小时读懂日语的架构",
-  taglineEn:
-    "Not greetings — the design principles of the language, for people who think in systems.",
-  taglineZh: "不是寒暄用语，而是这门语言的设计原理 —— 写给习惯用系统思维的人。",
-  readEn: "~1 hour",
-  readZh: "约 1 小时",
+  titleEn: "How a Japanese Sentence Is Built",
+  titleZh: "日语句子是怎么搭起来的",
+  taglineEn: "Read Japanese grammar like a programming language.",
+  taglineZh: "把日语语法当成一门编程语言来读。",
   introEn:
-    "You have one hour. Spend it on architecture, not on `こんにちは`. Most courses hand you phrases and hope the grammar assembles itself later; we'll do the opposite — install the seven load-bearing ideas first, so every phrase you meet afterwards snaps onto a frame you already understand.\n\nHere is the headline a programmer can hold onto: **Japanese is regular where English is irregular, and explicit where English is positional.** Grammatical roles are tagged, not guessed from word order; predicates are built by gluing endings onto stems with a near-total function; politeness and tense are dimensions of that function, not extra vocabulary. That regularity is exactly why this whole site can model sentences as *types* a compiler checks. Seven principles follow. Take them in order.",
+    "A Japanese sentence is put together by rules that are unusually regular — regular enough that this whole site models them as TypeScript types. We'll lean on that. For each idea below you'll see one thought written three ways: the **Japanese**, its closest **English**, and a small piece of **TypeScript** that makes the structural difference impossible to miss. You don't have to write TypeScript — reading it is enough, and it keeps the grammar terms (particle, topic, predicate) concrete instead of abstract. Read top to bottom; each idea rests on the one before it.",
   introZh:
-    "你有一个小时。把它花在架构上，而不是 `こんにちは`。多数教程先塞给你一堆短语，指望语法日后自己拼起来；我们反过来 —— 先装好七根承重梁，往后你遇到的每个短语都能扣进一个你已经理解的框架。\n\n给程序员一句能攥住的总纲：**在英语凭语序、靠记忆的地方，日语是显式而规则的。** 语法角色是被「标注」出来的，而不是从词序里猜的；谓语是把词尾「粘」到词干上、用一个近乎全函数的规则造出来的；礼貌和时态是这个函数的维度，而不是另一套词汇。正是这种规则性，才让整个网站能把句子建模成编译器可校验的「类型」。下面七条原理，请按顺序读。",
+    "日语句子是按一套异常规则的方式搭起来的 —— 规则到整个网站都把它们建模成了 TypeScript 类型。我们正好借这一点。下面每个概念，你都会看到同一个想法的三种写法：**日语**、最接近的**英语**，以及一小段让结构差异无所遁形的 **TypeScript**。你不必会写 TypeScript —— 能读就够了，它会把那些语法术语（助词、主题、谓语）从抽象变得具体。请从上往下读，每个概念都搭在前一个之上。",
   sections: [
     {
-      id: "agglutinative",
-      headingEn: "Meaning is built by gluing suffixes onto stems",
-      headingZh: "意义是把后缀「粘」到词干上造出来的",
-      blocks: [
-        {
-          kind: "prose",
-          en: "Start with the single fact that explains the most. Japanese is an **agglutinative** language: you take a root and stick small, regular pieces onto its end, one after another, each adding one unit of meaning. English mostly uses separate words and word order (*I did not eat*); Japanese grows one word longer (`食べ` → `食べない` → `食べなかった`).\n\nMentally, picture a builder pattern or a Unix pipe: a stem flows through a chain of suffixes, and each suffix is a small, composable transform. The pieces rarely fuse or mutate the way English *go → went* does. That regularity is the whole reason the grammar is *typeable* — and why the rest of this site can compute a sentence's surface form from its parts.",
-          zh: "先记住这条解释力最强的事实。日语是一门 **黏着语（agglutinative）**：你拿一个词根，把一个个小而规则的零件粘到它末尾，每个零件添一份意义。英语多用独立的词加语序（*I did not eat*）；日语则是把一个词越接越长（`食べ` → `食べない` → `食べなかった`）。\n\n在脑子里把它想成 builder 模式或 Unix 管道：一个词干流经一串后缀，每个后缀都是一个小而可组合的变换。这些零件很少像英语 *go → went* 那样融合、突变。正是这种规则性，让语法变得「可类型化」—— 也正因如此，本站才能从一个句子的各部分算出它的最终表面形式。",
-        },
-        {
-          kind: "define",
-          term: "膠着語",
-          reading: "こうちゃくご",
-          romaji: "kōchakugo",
-          en: "Agglutinative language — one that builds words by chaining separable, single-purpose suffixes onto a stem. Japanese, Korean and Turkish are the textbook cases.",
-          zh: "黏着语 —— 通过把可分离、各司其职的后缀链接到词干上来构词的语言。日语、韩语、土耳其语是典型代表。",
-        },
-      ],
-    },
-    {
-      id: "sov",
-      headingEn: "The predicate comes last — always",
-      headingZh: "谓语永远在最后",
-      blocks: [
-        {
-          kind: "prose",
-          en: "Japanese is **SOV**: Subject – Object – *Verb*. The word that does the asserting — the verb, adjective, or *noun + copula* — sits at the very end of the clause. English is SVO (*I eat sushi*); Japanese is \"I sushi eat.\"\n\nThink of the predicate as the operator and everything before it as its operands: the sentence accumulates arguments and only *applies* them at the final word. This is why a Japanese sentence can feel suspenseful — you don't learn whether it's a question, a negation, or a past tense until the end, because all of that lives in the tail. Rule of thumb: **read to the last word before you decide what the sentence means.**",
-          zh: "日语是 **SOV** 语序：主语 – 宾语 – *动词*。负责「下断言」的那个词 —— 动词、形容词，或 *名词＋系动词* —— 坐在小句的最末尾。英语是 SVO（*I eat sushi*）；日语则是「我 寿司 吃」。\n\n把谓语看作运算符，它前面的一切都是操作数：句子一路累积参数，直到最后一个词才真正「求值」。这也是日语句子常带悬念的原因 —— 它到底是疑问、否定还是过去时，你要读到末尾才知道，因为这些信息全都住在词尾里。经验法则：**读到最后一个词，再决定整句的意思。**",
-        },
-        {
-          kind: "example",
-          jp: "私は寿司を食べる",
-          reading: "わたしはすしをたべる",
-          en: "I eat sushi. (literally: I / sushi / eat)",
-          zh: "我吃寿司。（字面：我 / 寿司 / 吃）",
-        },
-        { kind: "chapters", ids: ["e01", "e05"] },
-      ],
-    },
-    {
       id: "particles",
-      headingEn: "Particles are postfix role-tags, so word order is free",
-      headingZh: "助词是后置的「角色标签」，所以词序是自由的",
+      headingEn: "Roles come from tags, not from position",
+      headingZh: "角色靠标签，不靠位置",
       blocks: [
         {
           kind: "prose",
-          en: "This is the keystone. After each noun comes a tiny **particle** that declares the noun's grammatical role: `は` marks the topic, `が` the subject, `を` the object, `に` the destination, `で` the location/means, `へ` the direction. The role travels *with* the noun as a suffix — it is not inferred from position.\n\nThe programmer's analogy is exact: particles are **named arguments**. English is positional — `f(a, b)` means something different from `f(b, a)`. Japanese is keyword-based — `食べる(topic=私, object=寿司)` means the same thing however you shuffle the middle. That's why the only rigid rule is *predicate-last* (Principle 2): once roles are tagged, their order stops mattering. Master the particle set and you've learned Japanese sentence structure; the rest is vocabulary and endings.",
-          zh: "这是拱心石。每个名词后面跟一个小小的 **助词**，用来声明该名词的语法角色：`は` 标记主题，`が` 标记主语，`を` 标记宾语，`に` 标记目的地，`で` 标记地点/方式，`へ` 标记方向。角色作为后缀「随名词一起走」—— 它不是从位置推断出来的。\n\n程序员的类比恰如其分：助词就是 **具名参数（named arguments）**。英语是位置式的 —— `f(a, b)` 和 `f(b, a)` 含义不同。日语是关键字式的 —— `食べる(topic=私, object=寿司)`，你怎么打乱中间都还是同一个意思。这正是为什么唯一刚性的规则是「谓语在最后」（原理 2）：角色一旦被标注，它们的先后就不再重要。把这套助词吃透，你就掌握了日语的句子结构；剩下的只是词汇和词尾。",
+          en: "Take the most basic English sentence and ask a strange question: how do you know **who** is doing the action? In 'the dog bit the man', the only thing telling you the dog did the biting is **word order** — 'dog' sits before the verb, 'man' after it. Swap them and the meaning reverses. English grammar is, at its core, positional.\n\nJapanese works the other way. Each noun is followed by a tiny word — a **particle** — that names its job in the sentence. Once a noun is tagged 'this is the subject' or 'this is the object', its position no longer carries that information, so the order becomes flexible. The tag does the work that English makes position do.",
+          zh: "拿最基础的英语句子，问一个奇怪的问题：你怎么知道是**谁**在做这个动作？在 'the dog bit the man'（狗咬了人）里，唯一告诉你是狗在咬的，是**语序** —— 'dog' 在动词前，'man' 在动词后。把两者调换，意思就反了。英语语法的内核是「靠位置」。\n\n日语反其道而行。每个名词后面都跟一个小词 —— **助词** —— 来点明它在句中的职责。名词一旦被贴上「这是主语」或「这是宾语」的标签，它的位置就不再承载这份信息，于是顺序变得灵活。标签干的，正是英语让位置去干的活。",
+        },
+        {
+          kind: "compare",
+          jp: "私はコーヒーを飲む",
+          reading: "わたしはコーヒーをのむ",
+          en: "I drink coffee.",
+          zh: "我喝咖啡。",
+          tsEn: `// English marks roles by POSITION — the slots are fixed:
+drink("I", "coffee")          // I drink coffee
+drink("coffee", "I")          // coffee drinks me — order flipped the meaning
+
+// Japanese marks roles by TAG — は = subject/topic, を = object:
+const subject = "私" + "は"          // tagged 'topic'
+const object  = "コーヒー" + "を"     // tagged 'object'
+
+// because the tags carry the roles, the order is free:
+"私はコーヒーを飲む"   // natural
+"コーヒーを私は飲む"   // object first — same meaning`,
+          tsZh: `// 英语靠位置标记角色 —— 槽位是固定的：
+drink("I", "coffee")          // 我喝咖啡
+drink("coffee", "I")          // 咖啡喝我 —— 顺序一换，意思就反了
+
+// 日语靠标签标记角色 —— は = 主语/主题，を = 宾语：
+const subject = "私" + "は"          // 贴上「主题」标签
+const object  = "コーヒー" + "を"     // 贴上「宾语」标签
+
+// 因为标签扛着角色，顺序是自由的：
+"私はコーヒーを飲む"   // 自然
+"コーヒーを私は飲む"   // 宾语在前 —— 意思相同`,
+          noteEn:
+            "`は` and `を` are glued onto the nouns like little labels. Move the labelled chunks around and the sentence still means the same thing — try that with the English and it breaks.",
+          noteZh:
+            "`は`、`を` 像小标签一样粘在名词上。把带标签的整块挪来挪去，句子意思不变 —— 同样的事在英语里一做就崩。",
         },
         {
           kind: "define",
           term: "助詞",
           reading: "じょし",
           romaji: "joshi",
-          en: "Particle — an uninflected grammatical marker placed *after* a word to assign its role (は が を に で …) or to glue clauses together. The closest English analogue is a preposition, but particles come after, not before, and never change shape.",
-          zh: "助词 —— 放在词语*之后*、用来指派其角色（は が を に で …）或连接小句的语法标记，本身不活用（不变形）。最接近的英语类比是介词，但助词后置而非前置，且永不变形。",
+          en: "Particle — a short word placed **after** a noun (or clause) that labels its grammatical job: `は`/`が` mark the subject-ish roles, `を` the object, `に` a destination or time, `で` a location or means, `へ` a direction. The nearest English thing is a preposition, but particles come *after* the word and never change form.",
+          zh: "助词 —— 放在名词（或小句）**之后**、给它的语法角色贴标签的短词：`は`/`が` 标记主语类角色，`を` 标记宾语，`に` 标记目的地或时间，`で` 标记地点或方式，`へ` 标记方向。最接近的英语类比是介词，但助词放在词*后面*，且永不变形。",
         },
         {
-          kind: "example",
-          jp: "寿司を私は食べる",
-          reading: "すしをわたしはたべる",
-          en: "I eat sushi. — object first this time, identical meaning: the `を` and `は` tags carry the roles, not the order.",
-          zh: "我吃寿司。—— 这次宾语在前，意思完全一样：是 `を`、`は` 这两个标签扛着角色，而不是词序。",
+          kind: "prose",
+          en: "A handful of particles covers most of what you'll read at first — think of them as the label set: `は` topic ('as for…', more in Principle 3), `が` subject (the doer), `を` object (the thing acted on), `に` destination/time ('to', 'at'), `で` location/means ('at a place', 'by a tool'), `へ` direction ('toward').\n\nBecause every role is spelled out, Japanese can drop whatever is obvious — including the subject — and still be unambiguous. `コーヒーを飲む` ('drink coffee') is a complete, normal sentence; the *who* is simply understood.",
+          zh: "少数几个助词就覆盖了你最初要读的绝大部分 —— 把它们当作一套标签：`は` 主题（「说到……」，详见原理 3）、`が` 主语（施事者）、`を` 宾语（被作用的东西）、`に` 目的地/时间（「到」「在」）、`で` 地点/方式（「在某地」「用某工具」）、`へ` 方向（「朝」）。\n\n正因为每个角色都被写明，日语可以省掉任何不言自明的成分 —— 包括主语 —— 还不产生歧义。`コーヒーを飲む`（喝咖啡）就是一句完整、自然的话；那个「谁」不说也懂。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "Each noun wears its role as a label (は, を). Because the labels carry the meaning, you could swap the order of the two and nothing changes.",
+          captionZh:
+            "每个名词都把自己的角色当标签戴着（は、を）。正因为标签扛着意思，你把这两个的顺序对调，意思也不变。",
+          root: {
+            label: "飲む",
+            args: [
+              { label: "私", tag: "は", roleEn: "topic", roleZh: "主题" },
+              { label: "コーヒー", tag: "を", roleEn: "object", roleZh: "宾语" },
+            ],
+          },
         },
         { kind: "chapters", ids: ["e01", "e05", "e06"] },
       ],
     },
     {
-      id: "wa-ga",
-      headingEn: "は vs が — topic versus subject (the famous trap)",
-      headingZh: "は 与 が —— 主题与主语之分（著名的坑）",
+      id: "predicate-last",
+      headingEn: "A clause is a function with the verb last — and sentences nest them",
+      headingZh: "小句是动词在最后的函数 —— 而句子把它们层层嵌套",
       blocks: [
         {
           kind: "prose",
-          en: "Two particles both translate to the English subject \"I\", and telling them apart is the first real puzzle every learner hits. They do different jobs.\n\n**`は` sets the topic** — \"as for X, ...\". It lifts something out as the frame the rest of the sentence comments on, and it often carries old/known information. **`が` marks the grammatical subject** — the specific doer, and often *new* information, the answer to \"who/what?\". `私は学生です` says \"speaking of me, [I'm] a student\" (topic). `誰が来た？ — 田中さんが来た` answers \"who came?\" with `が`, spotlighting the new subject. A useful first heuristic: **`は` frames, `が` identifies.** You will refine this for years, but that one sentence will carry you a long way.",
-          zh: "有两个助词都对应英语里作主语的「I」，分清它们是每个学习者撞上的第一道真正难题。它们干的是不同的活。\n\n**`は` 设定主题** —— 「说到 X，……」。它把某物拎出来当作框架，让句子其余部分对它作评述，且常承载旧的/已知的信息。**`が` 标记语法主语** —— 那个具体的施事者，常是*新*信息，是「谁/什么？」的答案。`私は学生です` 说的是「说到我，[我]是学生」（主题）；`誰が来た？ — 田中さんが来た` 用 `が` 回答「谁来了？」，把新主语打上聚光灯。一个好用的初步判据：**`は` 搭框架，`が` 作指认。** 这条你会打磨很多年，但单凭这一句就能带你走很远。",
+          en: "First, the one word this principle leans on: a **clause**. Everything below is about how clauses are shaped and how they nest inside one another, so let's pin the term down before we use it.",
+          zh: "先说这条原理要依赖的那个词：**小句**。下面讲的全是小句怎么成形、又怎么彼此嵌套，所以先把这个词定下来再用。",
+        },
+        {
+          kind: "define",
+          term: "節",
+          reading: "せつ",
+          romaji: "setsu",
+          en: "Clause — a group of words with its own predicate (its own closing verb, adjective, or noun-plus-copula). A whole sentence is one clause; a complex sentence is clauses nested inside other clauses. Japanese grammar calls it 節.",
+          zh: "小句（节，せつ）—— 拥有自己谓语（自己的收尾动词、形容词，或名词加系动词）的一组词。一句完整的话就是一个小句；复杂的句子，就是小句嵌在别的小句里。日语语法称它为「節」。",
+        },
+        {
+          kind: "prose",
+          en: "Here is the mental model that makes the rest click. Treat a **verb as a function** and the tagged nouns as the **arguments** you pass it. English writes the function name first, then the arguments: `eat(I, sushi)`. Japanese writes the **arguments first and the function last** — the same call, with the name moved to the end. The verb (or whatever does the asserting) is pinned to the very end of the clause, always.",
+          zh: "这是让其余一切都豁然开朗的思维模型。把**动词看作一个函数**，把带标签的名词看作传给它的**参数**。英语先写函数名，再写参数：`eat(I, sushi)`。日语则**参数在前、函数在最后** —— 同一个调用，只是把名字挪到了末尾。动词（或任何负责下断言的成分）永远被钉在小句的最末尾。",
+        },
+        {
+          kind: "compare",
+          jp: "私は寿司を食べる",
+          reading: "わたしはすしをたべる",
+          en: "I eat sushi.",
+          zh: "我吃寿司。",
+          tsEn: `// Treat the verb as a function, the nouns as its arguments.
+eat(I, sushi)        // English: the function (verb) comes FIRST
+(I, sushi, eat)      // Japanese: the verb comes LAST — 私は 寿司を 食べる`,
+          tsZh: `// 把动词看作函数，名词看作它的参数。
+eat(I, sushi)        // 英语：函数（动词）在最前
+(I, sushi, eat)      // 日语：动词在最后 —— 私は 寿司を 食べる`,
+          noteEn:
+            "Read to the last word before you decide what a Japanese sentence means — whether it's negative, past, or a question is all settled by that final verb, not by anything up front.",
+          noteZh:
+            "读到最后一个词，再判断一句日语的意思 —— 它是否定、过去还是疑问，全由结尾那个动词决定，跟前面无关。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "The clause as a picture: the tagged arguments feed into the verb, which closes the box at the end.",
+          captionZh:
+            "把这个小句画出来：带标签的参数汇入动词，而动词在末尾为这个盒子收尾。",
+          root: {
+            label: "食べる",
+            args: [
+              { label: "私", tag: "は", roleEn: "topic", roleZh: "主题" },
+              { label: "寿司", tag: "を", roleEn: "object", roleZh: "宾语" },
+            ],
+          },
+        },
+        {
+          kind: "prose",
+          en: "Now the part most courses bury, and the one that actually matters: **a whole clause can itself be an argument to another verb.** Sentences don't just line up — they **nest**, like function calls inside function calls. 'Tanaka said that I bought a book' is `say(Tanaka, bought(I, book))`. In Japanese, each verb still lands at the end of *its own* clause, so as clauses nest, their verbs stack up toward the end.",
+          zh: "接下来是大多数教程都埋没、却真正要紧的一点：**一整个小句本身可以成为另一个动词的参数。** 句子不是简单排队 —— 而是**嵌套**，像函数调用里套函数调用。「田中说我买了书」就是 `say(Tanaka, bought(I, book))`。在日语里，每个动词依然落在*它自己*小句的末尾，于是小句一层层嵌套时，动词也一个个往后堆。",
+        },
+        {
+          kind: "compare",
+          jp: "田中さんは私が本を買ったと言った",
+          reading: "たなかさんはわたしがほんをかったといった",
+          en: "Tanaka said that I bought a book.",
+          zh: "田中说我买了书。",
+          tsEn: `// A whole clause becomes an argument of another verb — calls in calls:
+say(Tanaka, bought(I, book))
+
+// Japanese keeps each verb at the END of its own clause. と ('that')
+// wraps the inner clause before the outer verb 言った consumes it:
+//   田中さんは [ 私が 本を 買った ] と 言った
+//   topic        (I-ga  book-wo  bought)  quote  said`,
+          tsZh: `// 一整个小句成为另一个动词的参数 —— 调用里套调用：
+say(Tanaka, bought(I, book))
+
+// 日语让每个动词都待在自己小句的末尾。と（「……这件事」）先把
+// 内层小句包起来，再交给外层动词 言った 去「消费」：
+//   田中さんは [ 私が 本を 買った ] と 言った
+//   主题         （我-が 书-を 买了）   引用   说了`,
+          noteEn:
+            "Read the verbs from the inside out: `買った` (bought) closes the inner thought, `言った` (said) closes the outer one. Two functions, two endings, nested — and that recursion is how Japanese builds long sentences.",
+          noteZh:
+            "从里往外读这些动词：`買った`（买了）结束内层的想法，`言った`（说了）结束外层的。两个函数，两个收尾，层层相套 —— 而这种递归，正是日语搭出长句的方式。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "Nesting, drawn out: the inner clause is a box that sits inside the outer one as a single argument. と is the tag that hands it over; each verb still closes its own box.",
+          captionZh:
+            "把嵌套画出来：内层小句是一个盒子，作为单个参数嵌在外层盒子里。と 是把它递交出去的标签；每个动词仍为自己的盒子收尾。",
+          root: {
+            label: "言った",
+            args: [
+              { label: "田中さん", tag: "は", roleEn: "topic", roleZh: "主题" },
+              {
+                label: "買った",
+                tag: "と",
+                roleEn: "inner clause, quoted with と",
+                roleZh: "内层小句，用 と 引用",
+                args: [
+                  { label: "私", tag: "が", roleEn: "subject", roleZh: "主语" },
+                  { label: "本", tag: "を", roleEn: "object", roleZh: "宾语" },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          kind: "prose",
+          en: "This nesting is not an exotic feature — it *is* the architecture. Relative clauses, quotations, reasons, conditions: all of them are just one clause handed to another as an argument, each closing with its own verb. Everything that turns a bare verb into 'didn't', 'will', or 'politely' attaches to those closing verbs — which is what the next principles are about.",
+          zh: "这种嵌套不是什么冷僻特性 —— 它*就是*整个架构。定语从句、引用、原因、条件：全都不过是把一个小句当参数交给另一个，各自用自己的动词收尾。一切把光秃秃的动词变成「没有」「将要」「礼貌地」的成分，都挂在这些收尾的动词上 —— 而这正是后面几条原理要讲的。",
+        },
+        {
+          kind: "compare",
+          jp: "私が買った本は高い",
+          reading: "わたしがかったほんはたかい",
+          en: "The book I bought is expensive.",
+          zh: "我买的书很贵。",
+          tsEn: `// A clause can also DESCRIBE a noun — that's a relative clause:
+isExpensive(book(boughtBy(I)))
+
+//   [ 私が 買った ] 本は 高い
+//   (I-ga   bought)  book(topic)  is-expensive
+//   the inner clause describes 本; then 本は is the topic of 高い`,
+          tsZh: `// 一个小句也可以「描述」一个名词 —— 这就是定语从句：
+isExpensive(book(boughtBy(I)))
+
+//   ［ 私が 買った ］ 本は 高い
+//   （我-が 买了）    书（主题）  贵
+//   内层小句描述「本」；然后 本は 是 高い 的主题`,
+          noteEn:
+            "Same recursion as before, but the inner clause now *modifies a noun* instead of being quoted. `買った` still closes its own clause; `高い` (an adjective — Principle 4) closes the sentence.",
+          noteZh:
+            "和之前一样的递归，只是内层小句这次去*修饰一个名词*，而不是被引用。`買った` 仍为自己的小句收尾；`高い`（一个形容词 —— 见原理 4）为整句收尾。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "A relative clause is the same nesting in another guise: [私が→買った] is a box that describes 本, which then becomes the topic of the adjective 高い.",
+          captionZh:
+            "定语从句是同一种嵌套换了身衣裳：[私が→買った] 是一个描述「本」的盒子，「本」再成为形容词 高い 的主题。",
+          root: {
+            label: "高い",
+            args: [
+              {
+                label: "買った",
+                roleEn: "inner clause — describes 本",
+                roleZh: "内层小句 —— 描述「本」",
+                args: [
+                  { label: "私", tag: "が", roleEn: "subject", roleZh: "主语" },
+                ],
+              },
+              { label: "本", tag: "は", roleEn: "topic", roleZh: "主题" },
+            ],
+          },
+        },
+        { kind: "chapters", ids: ["e01", "e05", "e20"] },
+      ],
+    },
+    {
+      id: "topic-subject",
+      headingEn: "Topic vs. subject — は and が",
+      headingZh: "主题与主语 —— は 和 が",
+      blocks: [
+        {
+          kind: "prose",
+          en: "Now the trap every learner trips on. Two particles, `は` and `が`, both look like they mark the English subject — and they are not interchangeable, because they answer different questions.\n\n`が` marks the grammatical **subject**: the specific thing doing or being something, often *new* information — the answer to 'who?' or 'what?'. `は` marks the **topic**: it lifts something up as the frame for the rest of the sentence, 'as for X, …', usually something already known. English has no dedicated word for the topic, so it hides inside the subject and we never notice the difference.",
+          zh: "现在轮到每个学习者都会栽的坑。`は` 和 `が` 这两个助词，看起来都像在标记英语的主语 —— 但它们不能互换，因为它们回答的是不同的问题。\n\n`が` 标记语法**主语**：那个具体地做某事或处于某状态的东西，常是*新*信息 —— 「谁？」「什么？」的答案。`は` 标记**主题**：它把某物拎出来，作为句子其余部分的框架，「说到 X，……」，通常是已知的东西。英语没有专门表示主题的词，于是主题藏在主语里，我们从不留意这点区别。",
+        },
+        {
+          kind: "define",
+          term: "主題",
+          reading: "しゅだい",
+          romaji: "shudai",
+          en: "Topic — what the sentence is *about*, announced up front with `は`, roughly 'as for…'. It frames the comment that follows, and it is **not necessarily the grammatical subject** — a topic can be a time, a place, or even the object.",
+          zh: "主题 —— 句子*在谈论*的东西，用 `は` 在句首点出，大致是「说到……」。它为后面的评述搭框架，而且**不一定是语法主语** —— 主题可以是时间、地点，甚至宾语。",
+        },
+        {
+          kind: "define",
+          term: "主語",
+          reading: "しゅご",
+          romaji: "shugo",
+          en: "Subject — the grammatical doer of the action or holder of the state, marked with `が` when it must be made explicit or is new information. This is 'the subject' in the ordinary English sense.",
+          zh: "主语 —— 动作的施事者或状态的承载者，在需要明示或属于新信息时用 `が` 标记。这就是英语通常意义上的「主语」。",
+        },
+        {
+          kind: "compare",
+          jp: "象は鼻が長い",
+          reading: "ぞうははながながい",
+          en: "Elephants have long noses. (literally: as for elephants, the nose is long)",
+          zh: "大象鼻子长。（字面：说到大象，鼻子长）",
+          tsEn: `// English forces ONE 'subject'. Japanese splits the job in two:
+const sentence = {
+  topic:     "象",    // は — 'as for the elephant…'
+  subject:   "鼻",    // が — '…the NOSE'
+  predicate: "長い",  // 'is long'
+}  // 象は鼻が長い`,
+          tsZh: `// 英语只能有一个「主语」。日语把这份活儿拆成两半：
+const sentence = {
+  topic:     "象",    // は —— 「说到大象……」
+  subject:   "鼻",    // が —— 「……是鼻子」
+  predicate: "長い",  // 「长」
+}  // 象は鼻が長い`,
+          noteEn:
+            "A first rule of thumb: **`は` frames, `が` identifies.** `私は` sets you as the topic under discussion; `誰が来た?` ('who came?') demands `が` because it's hunting for the specific subject. You'll refine this for years, but that one line carries you far.",
+          noteZh:
+            "一个初步判据：**`は` 搭框架，`が` 作指认。** `私は` 把你设为正在谈论的主题；`誰が来た?`（谁来了？）必须用 `が`，因为它在找那个具体的主语。这条你会打磨很多年，但单凭它就能走很远。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "Two different slots, side by side: 象は is the topic that frames the whole sentence, while 鼻が is the actual subject of 長い. English would have to pick just one 'subject'.",
+          captionZh:
+            "两个不同的槽，并排放着：象は 是为整句搭框架的主题，而 鼻が 才是 長い 真正的主语。换成英语，只能从中挑一个当「主语」。",
+          root: {
+            label: "長い",
+            args: [
+              { label: "象", tag: "は", roleEn: "topic (frame)", roleZh: "主题（框架）" },
+              { label: "鼻", tag: "が", roleEn: "subject", roleZh: "主语" },
+            ],
+          },
         },
         { kind: "chapters", ids: ["e01"] },
       ],
     },
     {
       id: "three-predicates",
-      headingEn: "Three kinds of predicate — and only two of them conjugate",
-      headingZh: "谓语只有三种 —— 而且只有两种会活用",
+      headingEn: "Three kinds of predicate — and a noun needs a copula",
+      headingZh: "三种谓语 —— 而名词需要系动词",
       blocks: [
         {
           kind: "prose",
-          en: "Every Japanese clause ends in a predicate, and there are exactly three kinds. Japanese grammar sorts words into two camps by one test — *does the word change shape on its own?* — and that test draws the line between the predicates that carry their own tense/politeness and the one that has to borrow.",
-          zh: "每个日语小句都以谓语收尾，而谓语恰好只有三种。日语语法用一个测试把词分成两大阵营 —— *这个词自己会不会变形？* —— 这个测试划出了那条界线：哪些谓语自带时态/礼貌，哪个必须去借。",
+          en: "Principle 2 said every clause ends in a predicate — the function that closes it. Exactly three kinds of word can play that role, and Japanese sorts them by a single test: **does the word change its own shape, or not?**",
+          zh: "原理 2 说过，每个小句都以谓语收尾 —— 就是那个为它收尾的函数。能担当这个角色的词恰好有三种，而日语用一个测试给它们分类：**这个词自己会不会变形？**",
         },
         {
           kind: "define",
           term: "用言",
           reading: "ようげん",
           romaji: "yōgen",
-          en: "Inflecting words — words that are predicates on their own and change shape (conjugate): verbs (動詞) and adjectives (形容詞). A 用言 can end a sentence by itself: 食べる (eat), 高い (is expensive).",
-          zh: "用言 —— 自身就能充当谓语、并且会变形（活用）的词：动词（動詞）和形容词（形容詞）。一个用言能独立结句：食べる（吃）、高い（贵）。",
+          en: "Inflecting words — **verbs** and **adjectives**. They are complete predicates on their own and they change shape (conjugate). `食べる` (eat) and `高い` (is expensive) can each end a sentence with no help.",
+          zh: "用言 —— **动词**和**形容词**。它们自身就是完整的谓语，并且会变形（活用）。`食べる`（吃）和 `高い`（贵）都能独立结句，无需帮手。",
         },
         {
           kind: "define",
           term: "体言",
           reading: "たいげん",
           romaji: "taigen",
-          en: "Non-inflecting words — nouns. A 体言 never changes shape and cannot end a statement by itself; to assert \"X is …\" it must borrow the copula (だ/です). 学生 (student) is a 体言; to predicate it you say 学生だ / 学生です.",
-          zh: "体言 —— 不变形的词，即名词。体言永不变形，也不能独立结句；要表达「X 是……」，它必须借用系动词（だ/です）。学生 是体言；要让它作谓语，得说 学生だ / 学生です。",
+          en: "Non-inflecting words — **nouns**. A noun never changes shape and cannot end a statement by itself. To say 'X is a student', it borrows a helper called the copula (`だ`/`です`).",
+          zh: "体言 —— 不变形的词，即**名词**。名词永不变形，也不能独立结句。要说「X 是学生」，它得借一个叫系动词（`だ`/`です`）的帮手。",
         },
         {
           kind: "prose",
-          en: "So the three predicates are:\n\n**1. Verb (動詞, a 用言)** — an action: `食べる` *eat*, `行く* *go*. Conjugates on its own.\n**2. Adjective (形容詞, a 用言)** — a property, in two flavors: *i-adjectives* (`高い` expensive) which conjugate like verbs, and *na-adjectives* (`静か` quiet) which are really noun-like roots that lean on the copula. \n**3. Noun + copula (体言 + コピュラ)** — `学生だ` *is a student*. The noun supplies the meaning; the copula `だ`/`です` supplies the \"…is\" and does the inflecting.\n\nA type-theory reader can read this as a **sum type**: `Predicate = Verb | Adjective | (Noun × Copula)`. Two of the three inflect themselves; the third delegates inflection to the copula. That is the single most clarifying picture of Japanese grammar — and the exact shape this site's type library models.",
-          zh: "于是三种谓语是：\n\n**1. 动词（動詞，用言）** —— 一个动作：`食べる` *吃*、`行く` *去*。自身就会活用。\n**2. 形容词（形容詞，用言）** —— 一种性质，分两种风味：*い形容词*（`高い` 贵）像动词一样活用，以及 *な形容词*（`静か` 安静），它们本质上是接近名词的词根，要靠系动词。\n**3. 名词＋系动词（体言＋コピュラ）** —— `学生だ` *是学生*。名词提供意义，系动词 `だ`/`です` 提供「……是」并负责变形。\n\n懂类型论的读者可以把它读成一个 **和类型（sum type）**：`Predicate = Verb | Adjective | (Noun × Copula)`。三者里有两个自己活用，第三个把活用委托给系动词。这是关于日语语法最具廓清力的一张图 —— 也正是本站类型库所建模的形状。",
+          en: "Here's the catch English speakers miss. In English *every* statement needs the verb 'to be': 'it is **expensive**', 'she is **a student**' — so you expect a word for 'is' everywhere. Japanese needs a copula only for the **noun** case. An adjective already contains its 'is':",
+          zh: "这里有个英语母语者常忽略的关键。在英语里，*每一句*陈述都需要 be 动词：'it is **expensive**'、'she is **a student**' —— 于是你以为到处都要有个「是」。可日语只在**名词**这种情况才需要系动词。形容词自身就已经含着那个「是」：",
         },
         {
-          kind: "define",
-          term: "コピュラ",
-          romaji: "copula",
-          en: "Copula — the linking word だ (plain) / です (polite) that turns a noun into a \"X is Y\" statement. It is not a particle: it inflects (だ → だった → ではない …), so it behaves like a tiny third predicate-engine alongside verbs and adjectives.",
-          zh: "系动词（コピュラ）—— 把名词变成「X 是 Y」陈述的连系词 だ（简体）/ です（礼貌）。它不是助词：它会活用（だ → だった → ではない …），所以它像第三台微型「谓语引擎」，与动词、形容词并列。",
+          kind: "compare",
+          jp: "高い",
+          reading: "たかい",
+          en: "(It) is expensive.",
+          zh: "（它）贵。",
+          tsEn: `// English: the adjective NEEDS a separate 'is'.
+"it" + " is " + "expensive"
+
+// Japanese: 高い already MEANS 'is expensive' — there is no 'is' word.
+"高い"        // a complete sentence: '(it) is expensive'
+"高いだ"      // WRONG — never bolt a copula onto an adjective`,
+          tsZh: `// 英语：形容词需要一个单独的「是」。
+"it" + " is " + "expensive"
+
+// 日语：高い 本身就是「（是）贵的」—— 根本没有「是」这个词。
+"高い"        // 一句完整的话：「（它）贵」
+"高いだ"      // 错 —— 绝不要给形容词硬加系动词`,
+          noteEn:
+            "`高い` is not the word 'expensive'; it's the whole statement 'is expensive'. Verbs and adjectives are self-contained predicates.",
+          noteZh:
+            "`高い` 不是「贵」这个词，而是「（是）贵的」这整句陈述。动词和形容词都是自带谓语的。",
         },
-        { kind: "chapters", ids: ["e05", "e08", "e01", "e13"] },
+        {
+          kind: "compare",
+          jp: "学生です",
+          reading: "がくせいです",
+          en: "(I) am a student.",
+          zh: "（我）是学生。",
+          tsEn: `// A noun can't assert on its own. The three predicate kinds, as a union:
+type Predicate =
+  | Verb            // 食べる    eat
+  | Adjective       // 高い      is expensive
+  | NounWithCopula  // 学生です   is a student
+
+"学生"        // just a noun: 'student' — not a sentence
+"学生です"    // noun + copula です → '(I) am a student'`,
+          tsZh: `// 名词无法独立下断言。三种谓语，写成一个联合类型：
+type Predicate =
+  | Verb            // 食べる    吃
+  | Adjective       // 高い      （是）贵
+  | NounWithCopula  // 学生です   （是）学生
+
+"学生"        // 只是个名词：「学生」—— 不成句
+"学生です"    // 名词 + 系动词 です → 「（我）是学生」`,
+          noteEn:
+            "The copula `だ`/`です` is the noun's borrowed 'is'. It's also the one piece here that itself inflects — which leads straight into the last principle.",
+          noteZh:
+            "系动词 `だ`/`です` 就是名词借来的「是」。它也是这里唯一自身会变形的部分 —— 这正好引出最后一条原理。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "A verb or adjective could close a clause alone. A noun can't — so です, the copula, takes the closing slot. 学生 is just the complement it carries.",
+          captionZh:
+            "动词或形容词能独自为小句收尾。名词不能 —— 于是系动词 です 占住了收尾的槽位，而 学生 只是它带着的那个名词。",
+          root: {
+            label: "です",
+            args: [
+              { label: "私", tag: "は", roleEn: "topic", roleZh: "主题" },
+              { label: "学生", roleEn: "noun (complement)", roleZh: "名词（谓语核心）" },
+            ],
+          },
+        },
+        { kind: "chapters", ids: ["e01", "e08", "e05", "e13"] },
       ],
     },
     {
       id: "conjugation",
-      headingEn: "Conjugation is a pure function: (word, form) → string",
-      headingZh: "活用是一个纯函数：(词, 形) → 字符串",
+      headingEn: "Inflection swaps the ending, it doesn't add words",
+      headingZh: "变形靠改词尾，不靠加词",
       blocks: [
         {
           kind: "prose",
-          en: "Here is where the architecture pays off. A 用言 (or the copula) doesn't get *new words* for past, negative, polite, or \"let's…\". It transforms its **tail** into one of a small, fixed set of **forms** (活用形). Given the word and the form name, the surface string is determined — deterministic, finite, no agreement with the subject. It is, almost literally, a pure function.\n\nThis is the thesis of *Typed Japanese*: if conjugation is a total function, you can encode it in a type system and let the compiler compute (and check) the result. `ConjugateVerb<食べる, \"て形\">` evaluates to the string `\"食べて\"`. Negation, tense and politeness are just different `form` arguments to the same function — you are not memorizing irregular forms, you are calling a method.",
-          zh: "架构的回报在这里兑现。一个用言（或系动词）并不会为过去、否定、礼貌、「我们来……吧」换上*新词*。它把自己的 **词尾** 变换成一组小而固定的 **活用形** 之一。给定词与活用形名，表面字符串就被确定下来 —— 确定、有限、不与主语作一致变化。它几乎就是字面意义上的纯函数。\n\n这正是 *Typed Japanese* 的核心命题：如果活用是一个全函数，你就能把它编码进类型系统，让编译器去算（并校验）结果。`ConjugateVerb<食べる, \"て形\">` 求值为字符串 `\"食べて\"`。否定、时态、礼貌只是同一个函数的不同 `form` 参数 —— 你不是在背不规则变化，你是在调用一个方法。",
+          en: "Last piece, and it's where the regularity turns almost mechanical. To say *not*, *did*, *will*, or *politely*, English keeps the verb fixed and stacks helper words around it: 'eat' → 'did not eat' → 'will eat'. Japanese keeps it to **one word** and rewrites its **ending**:",
+          zh: "最后一块，也是规则性变得近乎机械的地方。要表达*否定*、*过去*、*将来*或*礼貌*，英语让动词不动，在它周围堆助词：'eat' → 'did not eat' → 'will eat'。日语只用**一个词**，改写它的**词尾**：",
+        },
+        {
+          kind: "compare",
+          jp: "食べる → 食べない → 食べた → 食べます",
+          reading: "たべる → たべない → たべた → たべます",
+          en: "eat → don't eat → ate → eat (polite)",
+          zh: "吃 → 不吃 → 吃了 → 吃（礼貌）",
+          tsEn: `// English wraps the verb in helper words; 'eat' itself stays put.
+"eat"  ->  "do not eat"  ->  "will eat"  ->  "ate"
+
+// Japanese rewrites the ENDING of one verb. Same stem 食べ, new tail:
+conjugate("食べる", "negative") === "食べない"   // 食べ + ない
+conjugate("食べる", "past")     === "食べた"     // 食べ + た
+conjugate("食べる", "polite")   === "食べます"   // 食べ + ます`,
+          tsZh: `// 英语用助词把动词裹起来；动词「eat」本身一动不动。
+"eat"  ->  "do not eat"  ->  "will eat"  ->  "ate"
+
+// 日语改写同一个动词的词尾。词干 食べ 不变，换个尾巴：
+conjugate("食べる", "negative") === "食べない"   // 食べ + ない（否定）
+conjugate("食べる", "past")     === "食べた"     // 食べ + た（过去）
+conjugate("食べる", "polite")   === "食べます"   // 食べ + ます（礼貌）`,
+          noteEn:
+            "Politeness is just another ending: plain `食べる` vs. polite `食べます`, plain `学生だ` vs. polite `学生です`. Same meaning, different tail — and you pick a level for every sentence you speak.",
+          noteZh:
+            "礼貌也不过是另一种词尾：简体 `食べる` 对礼貌 `食べます`，简体 `学生だ` 对礼貌 `学生です`。意思相同，词尾不同 —— 而你说的每一句话都要选一个语体。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "Only the ending moves. The stem 食べ is fixed; each form is the same word wearing a different tail (shown in pink).",
+          captionZh:
+            "动的只有词尾。词干 食べ 固定不变；每个形都是同一个词换了一条尾巴（粉色部分）。",
+          row: [
+            { label: "食べ", tag: "る", roleEn: "dictionary", roleZh: "辞书形" },
+            { label: "食べ", tag: "ない", roleEn: "negative", roleZh: "否定" },
+            { label: "食べ", tag: "た", roleEn: "past", roleZh: "过去" },
+            { label: "食べ", tag: "ます", roleEn: "polite", roleZh: "礼貌" },
+          ],
         },
         {
           kind: "define",
           term: "活用",
           reading: "かつよう",
           romaji: "katsuyō",
-          en: "Conjugation / inflection — the systematic reshaping of a 用言's or the copula's ending to express tense, polarity, politeness, mood, or connection. Each target is a named 活用形 (form), e.g. て形, ない形, ます形.",
-          zh: "活用 —— 对用言或系动词词尾进行系统性变形，以表达时态、肯否、礼貌、语气或连接。每个目标都是一个有名字的 *活用形*，如 て形、ない形、ます形。",
+          en: "Conjugation / inflection — the systematic reshaping of a verb's, adjective's, or copula's **ending** to express tense, negation, politeness, or mood. The stem stays; only the tail changes, by fixed rules.",
+          zh: "活用 —— 对动词、形容词或系动词**词尾**进行系统性改写，以表达时态、否定、礼貌或语气。词干不变，只有词尾按固定规则变化。",
         },
         {
-          kind: "example",
-          jp: "食べる → 食べない → 食べた → 食べて",
-          reading: "たべる → たべない → たべた → たべて",
-          en: "eat → not eat → ate → eating/and(connective). One stem, four forms — same function, different `form` argument.",
-          zh: "吃 → 不吃 → 吃了 → 吃（て形/连接）。同一个词干，四个形 —— 同一个函数，不同的 `form` 参数。",
+          kind: "prose",
+          en: "Because those rules are fixed and finite, the ending is **computable** from the stem and the form you want — which is the entire premise of this site. `食べる` plus the form 'て' *is* `食べて`, the way a function returns a value. That's why a Japanese sentence here can be a TypeScript type the compiler checks: not a metaphor, but the same determinism you just saw in every `conjugate(...)` line above.",
+          zh: "正因为这些规则固定而有限，词尾可以由词干和你想要的活用形**算出来** —— 这就是整个网站的根本前提。`食べる` 加上「て」这个形，*就等于* `食べて`，像函数返回一个值一样。这也是为什么这里一句日语能成为编译器可校验的 TypeScript 类型：不是比喻，而是你刚在上面每一行 `conjugate(...)` 里看到的同一种确定性。",
         },
         { kind: "chapters", ids: ["e05", "e08", "e13"] },
       ],
     },
     {
-      id: "politeness",
-      headingEn: "Politeness is a grammatical axis, not a word choice",
-      headingZh: "礼貌是语法的一根轴，不是选词",
-      blocks: [
-        {
-          kind: "prose",
-          en: "In English, politeness is mostly word choice and hedging (*gimme* vs *could I have*). In Japanese it is **built into the grammar**: the very same proposition exists at different politeness levels, and you move between them by changing the predicate's ending, not by swapping vocabulary. `食べる` (plain) and `食べます` (polite) are the same verb, same meaning, different register; `学生だ` and `学生です` likewise. Above that sits 敬語 (honorific/humble speech), a whole further layer for status and deference.\n\nThe practical consequence: **register is a dimension you set, like a flag**, and it lives in the tail you already control via conjugation (Principle 6). You will choose plain or polite for *every* sentence — there is no neutral default — so it pays to feel, early, that the ending is doing social work as well as grammatical work.",
-          zh: "在英语里，礼貌多半是选词和措辞的软化（*gimme* 对 *could I have*）。在日语里，它是 **嵌进语法里的**：同一个命题存在于不同的礼貌层级，你在它们之间切换靠的是改谓语词尾，而不是换词汇。`食べる`（简体）与 `食べます`（礼貌）是同一个动词、同一个意思、不同的语体；`学生だ` 与 `学生です` 也一样。再往上还有 敬語（尊敬语/谦让语），那是为身份与敬意准备的又一整层。\n\n实际后果是：**语体是你要设定的一个维度，像一个开关标志**，而它就住在你已经能通过活用（原理 6）掌控的词尾里。你会为*每一*句话选择简体或礼貌 —— 没有中性的默认值 —— 所以越早体会到「词尾既在干语法的活、也在干社交的活」，越划算。",
-        },
-        { kind: "chapters", ids: ["e13", "i04", "i05"] },
-      ],
-    },
-    {
-      id: "next",
-      headingEn: "Where to go from here",
-      headingZh: "接下来去哪儿",
+      id: "together",
+      headingEn: "Putting it together — one sentence, all five",
+      headingZh: "把它们拼起来 —— 一句话，五条全用上",
       numbered: false,
       blocks: [
         {
           kind: "prose",
-          en: "That's the frame. With the seven principles in hand, the Grammar Course stops looking like a list of disconnected patterns and starts looking like an API: nouns get tagged with particles (Principle 3), the clause ends in one of three predicates (Principle 5), and you dial in tense and politeness by conjugating the tail (Principles 6–7).\n\nA sensible first path through the Course: start with the **noun + copula** sentence (`です`/`だ`), then **verbs** and the `を` object, then the everyday **particles**, then **adjectives**, then the **plain (普通) forms** that unlock casual speech and most advanced grammar. Open any sentence in the **Playground** to watch its type resolve, piece by piece, to the Japanese you just read.",
-          zh: "框架就是这些。手握这七条原理，语法教程不再像一串互不相干的句型，而开始像一套 API：名词用助词打标签（原理 3），小句以三种谓语之一收尾（原理 5），你通过给词尾活用来拨入时态与礼貌（原理 6–7）。\n\n一条合理的入门路线：先学 **名词＋系动词** 句（`です`/`だ`），再学 **动词** 与 `を` 宾语，接着是日常 **助词**，然后是 **形容词**，最后是解锁口语与大部分高级语法的 **简体（普通）形**。在 **演练场** 里打开任意句子，看它的类型如何一块一块地求值成你刚读到的那句日语。",
+          en: "No principle lives alone. A real sentence runs them all at once and nests them, exactly like the function-in-function shape from Principle 2. Here's one a beginner would find opaque — and that you can now take apart cleanly:",
+          zh: "没有一条原理是孤立的。真实的句子会把它们同时跑起来、层层嵌套，正是原理 2 那种「函数里套函数」的形状。下面这句，初学者会觉得不透 —— 而你现在能干净利落地把它拆开：",
+        },
+        {
+          kind: "breakdown",
+          jp: "私は田中さんが図書館で借りた本を読みました",
+          reading: "わたしはたなかさんがとしょかんでかりたほんをよみました",
+          en: "I read the book that Tanaka borrowed at the library.",
+          zh: "我读了田中在图书馆借的那本书。",
+          layers: [
+            {
+              fragment: "私は",
+              depth: 0,
+              en: "**topic** (`は`) — as for me, the one doing the reading",
+              zh: "**主题**（`は`）—— 说到我，也就是读书的人",
+            },
+            {
+              fragment: "田中さんが",
+              depth: 1,
+              en: "**subject** (`が`) — Tanaka, the doer *inside* a mini-clause that describes the book",
+              zh: "**主语**（`が`）—— 田中，是*描述这本书*的小句里的施事者",
+            },
+            {
+              fragment: "図書館で",
+              depth: 1,
+              en: "**place** (`で`) — at the library (still inside that mini-clause)",
+              zh: "**地点**（`で`）—— 在图书馆（仍在那个小句里）",
+            },
+            {
+              fragment: "借りた",
+              depth: 1,
+              en: "**inner verb** — plain past of 借りる 'borrow'; it ends the clause and the whole clause now describes 本",
+              zh: "**内层动词** —— 借りる「借」的简体过去；它结束这个小句，整段小句就成了 本 的修饰语",
+            },
+            {
+              fragment: "本を",
+              depth: 0,
+              en: "**object** (`を`) — the book: the very one the inner clause just described",
+              zh: "**宾语**（`を`）—— 那本书：正是内层小句刚刚描述的那一本",
+            },
+            {
+              fragment: "読みました",
+              depth: 0,
+              en: "**main verb** — polite past of 読む 'read'; the outer clause's final word",
+              zh: "**主句动词** —— 読む「读」的礼貌过去；外层小句的收尾词",
+            },
+          ],
+        },
+        {
+          kind: "compare",
+          jp: "私は田中さんが図書館で借りた本を読みました",
+          reading: "わたしはたなかさんがとしょかんでかりたほんをよみました",
+          en: "I read the book that Tanaka borrowed at the library.",
+          zh: "我读了田中在图书馆借的那本书。",
+          tsEn: `// Same nesting as Principle 2 — one call wrapped inside another:
+read(                               // 読みました — outer verb, LAST
+  topic:  I,                        // 私は
+  object: theBook(                  // 本を — and which book?
+    borrowed(Tanaka, atLibrary)     // [ 田中さんが 図書館で 借りた ]
+  ),
+)
+
+// Every principle is here at once:
+// 1 tags (は が で を)   2 verbs last & nested   3 は vs が
+// 4 a verb-predicate (読む) closes it   5 endings: 借りた past, 読みました polite-past`,
+          tsZh: `// 和原理 2 一样的嵌套 —— 一个调用包在另一个里面：
+read(                               // 読みました —— 外层动词，在最后
+  topic:  I,                        // 私は
+  object: theBook(                  // 本を —— 是哪本书？
+    borrowed(Tanaka, atLibrary)     // ［ 田中さんが 图书馆で 借りた ］
+  ),
+)
+
+// 五条原理在此同时出现：
+// 1 标签（は が で を）  2 动词在最后且嵌套  3 は 与 が
+// 4 用动词谓语（読む）收尾  5 词尾：借りた 过去、読みました 礼貌过去`,
+          noteEn:
+            "Read it inside-out, exactly like nested function calls: `借りた` closes the clause describing the book, then `読みました` closes the whole sentence. That's the entire architecture in one line of Japanese.",
+          noteZh:
+            "像读嵌套的函数调用一样，从里往外读：`借りた` 结束描述这本书的小句，然后 `読みました` 结束整句。这一行日语里，就装着全部的架构。",
+        },
+        {
+          kind: "diagram",
+          captionEn:
+            "The same sentence as nested boxes. The inner clause describes 本 and rides along as one argument; 読みました closes the whole thing at the very end.",
+          captionZh:
+            "同一句话画成嵌套的盒子。内层小句描述「本」，作为一个参数一起被带入；読みました 在最末尾为整句收尾。",
+          root: {
+            label: "読みました",
+            args: [
+              { label: "私", tag: "は", roleEn: "topic", roleZh: "主题" },
+              {
+                label: "借りた",
+                roleEn: "inner clause — describes 本",
+                roleZh: "内层小句 —— 描述「本」",
+                args: [
+                  {
+                    label: "田中さん",
+                    tag: "が",
+                    roleEn: "subject",
+                    roleZh: "主语",
+                  },
+                  { label: "図書館", tag: "で", roleEn: "place", roleZh: "地点" },
+                ],
+              },
+              { label: "本", tag: "を", roleEn: "object", roleZh: "宾语" },
+            ],
+          },
+        },
+        {
+          kind: "prose",
+          en: "That's the whole frame: **tag** each noun with a particle, **order** the tagged pieces freely, set **topic** and **subject** with `は`/`が`, close each clause with a **predicate** at the end, **nest** clauses inside one another, and **inflect** those closing predicates for tense and politeness. The **Grammar Course** now reads less like a list of patterns and more like filling in this frame one feature at a time — start with the noun sentence (`です`/`だ`), then verbs and the `を` object, then the everyday particles, then adjectives. And whenever a sentence looks opaque, drop it into the **Playground** and watch its type resolve, ending and all, into the Japanese you're reading.",
+          zh: "这就是整个框架：给每个名词**贴标签**（助词），把带标签的零件**自由排序**，用 `は`/`が` 设定**主题**与**主语**，让每个小句都以末尾的**谓语**收尾，把小句**层层嵌套**，再为这些收尾的谓语做时态与礼貌的**活用**。现在再看**语法教程**，它不再像一串句型清单，而更像往这个框架里一次填一个特性 —— 从名词句（`です`/`だ`）开始，然后是动词与 `を` 宾语，接着是日常助词，再到形容词。而每当一句话看不透，就把它丢进**演练场**，看它的类型连词尾一起，求值成你正在读的那句日语。",
         },
         { kind: "chapters", ids: ["e01", "e05", "e06", "e08", "e13"] },
       ],

--- a/playground/src/concepts/types.ts
+++ b/playground/src/concepts/types.ts
@@ -1,9 +1,9 @@
 /**
  * Content model for "Foundations" (原理) — standalone concept articles that
- * explain the *architecture* of Japanese, programming-language-101 style, rather
- * than walking the grammar syllabus. They are independent from the grammar
- * Course, the Glossary and the Playground, and they deep-link INTO the Course
- * chapters where each idea is drilled.
+ * explain the *architecture* of Japanese rather than walking the grammar
+ * syllabus. They are independent from the grammar Course, the Glossary and the
+ * Playground, and they deep-link INTO the Course chapters where each idea is
+ * drilled.
  *
  * Every string is bilingual (English + 简体中文). Prose supports inline `code`
  * spans (backticks) and **bold** spans.
@@ -14,7 +14,7 @@ export type ConceptBlock =
   // A run of paragraphs (split on blank lines). Supports `code` and **bold**.
   | { kind: "prose"; en: string; zh: string }
   // A defined term — rendered as a callout so a beginner never meets a jargon
-  // word (体言, 助詞, …) without its definition right there.
+  // word (体言, 助詞, 主題 …) without its definition right there.
   | {
       kind: "define";
       term: string;
@@ -23,10 +23,68 @@ export type ConceptBlock =
       en: string;
       zh: string;
     }
-  // A Japanese example line (display only — not necessarily a typed snippet).
+  // The core teaching unit: one thought shown three ways — the Japanese, its
+  // English counterpart, and a small piece of TypeScript that makes the
+  // structural difference concrete. The TS is per-language so the comments are
+  // in the reader's language; it is syntax-highlighted by the renderer.
+  | {
+      kind: "compare";
+      jp: string;
+      reading?: string;
+      en: string;
+      zh: string;
+      /** Lightweight, readable TypeScript with English comments. */
+      tsEn: string;
+      /** Same code, comments in 简体中文. */
+      tsZh: string;
+      noteEn?: string;
+      noteZh?: string;
+    }
+  // Peel a complex sentence apart, layer by layer, to show the principles
+  // composing. Each layer is a Japanese fragment with a role gloss; `depth`
+  // indents nested clauses.
+  | {
+      kind: "breakdown";
+      jp: string;
+      reading?: string;
+      en: string;
+      zh: string;
+      layers: { fragment: string; depth?: number; en: string; zh: string }[];
+    }
+  // A node-composition diagram: a clause is a verb (function) applied to tagged
+  // arguments; a clause can itself be an argument of another, so it nests. See
+  // {@link DiagramNode}.
+  | {
+      kind: "diagram";
+      captionEn?: string;
+      captionZh?: string;
+      /** A composition tree (clause with nested args). */
+      root?: DiagramNode;
+      /** OR a flat row of independent chips (e.g. one verb in several forms). */
+      row?: DiagramNode[];
+    }
+  // A plain Japanese example line (display only).
   | { kind: "example"; jp: string; reading?: string; en: string; zh: string }
   // "Where this is taught" — links into Course chapters by id (e.g. "e01").
   | { kind: "chapters"; ids: string[] };
+
+/**
+ * One node in a composition diagram.
+ * - A **leaf** (no `args`) is a tagged argument — a noun chip plus its particle.
+ * - A **clause** (has `args`) is a box whose `label` is the verb that closes it;
+ *   its `args` render inside, and an arg may itself be a clause — that's nesting.
+ */
+export interface DiagramNode {
+  /** Japanese surface: a noun for a leaf, or the closing verb for a clause. */
+  label: string;
+  /** Particle attached after this node (は / が / を / で / と …), shown as a chip. */
+  tag?: string;
+  /** Short role gloss shown under the chip. */
+  roleEn?: string;
+  roleZh?: string;
+  /** Argument nodes. Present ⇒ this node is a clause and `label` is its verb. */
+  args?: DiagramNode[];
+}
 
 export interface ConceptSection {
   id: string;
@@ -43,16 +101,11 @@ export interface ConceptArticle {
   id: string;
   /** Order in the Foundations list. */
   order: number;
-  /** Emoji shown in the list and header. */
-  icon: string;
   titleEn: string;
   titleZh: string;
-  /** One-line hook for the list. */
+  /** One-line hook for the list and header. */
   taglineEn: string;
   taglineZh: string;
-  /** Read-time hook, e.g. "~1 hour" / "约 1 小时". */
-  readEn: string;
-  readZh: string;
   /** Lead paragraph(s) under the title. Supports `code` and **bold**. */
   introEn: string;
   introZh: string;

--- a/playground/src/context/lang.tsx
+++ b/playground/src/context/lang.tsx
@@ -1,12 +1,7 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useState,
-  type ReactNode,
-} from "react";
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import { useRoute, type Lang } from "./route";
 
-export type Lang = "en" | "zh";
+export type { Lang };
 
 interface LangCtx {
   lang: Lang;
@@ -18,23 +13,27 @@ interface LangCtx {
 const Ctx = createContext<LangCtx | null>(null);
 const STORAGE_KEY = "tj-lang";
 
-function initialLang(): Lang {
-  if (typeof localStorage !== "undefined") {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v === "en" || v === "zh") return v;
-  }
-  return "en";
-}
-
+/**
+ * Language lives in the route (the URL), so switching it is a navigable action
+ * with Back / Forward support and is shareable. We mirror the choice to
+ * localStorage so a fresh visit (no `lang` in the URL) restores the last pick.
+ */
 export function LangProvider({ children }: { children: ReactNode }) {
-  const [lang, setLangState] = useState<Lang>(initialLang);
+  const { route, navigate } = useRoute();
+  const lang = route.lang;
 
-  const setLang = useCallback((l: Lang) => {
-    setLangState(l);
-    if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, l);
-  }, []);
+  const setLang = useCallback(
+    (l: Lang) => {
+      if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, l);
+      navigate({ lang: l });
+    },
+    [navigate]
+  );
 
-  const t = useCallback((en: string, zh: string) => (lang === "zh" ? zh : en), [lang]);
+  const t = useCallback(
+    (en: string, zh: string) => (lang === "zh" ? zh : en),
+    [lang]
+  );
 
   return <Ctx.Provider value={{ lang, setLang, t }}>{children}</Ctx.Provider>;
 }

--- a/playground/src/context/route.tsx
+++ b/playground/src/context/route.tsx
@@ -1,0 +1,155 @@
+/**
+ * Hash-based routing — the URL is the single source of truth for navigation, so
+ * tab switches, cross-section jumps (Glossary → example, Foundations → chapter),
+ * the selected chapter/article, and the UI language all work with the browser's
+ * Back / Forward buttons and are shareable as links.
+ *
+ * Hash shape:  #/<section>[/<sub>]?ex=<anchor>&lang=<en|zh>
+ *   #/foundations            #/foundations/architecture
+ *   #/course                 #/course/e01           #/course/e01?ex=ex-e01-e01-2-0
+ *   #/glossary               #/playground
+ *
+ * Hash routing (not the History API) is deliberate: it needs no server rewrite,
+ * so it works as-is on GitHub Pages.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Tab = "concepts" | "tutorial" | "glossary" | "playground";
+export type Lang = "en" | "zh";
+
+export interface Route {
+  tab: Tab;
+  /** Foundations: selected article id. */
+  article?: string;
+  /** Course: selected chapter id. */
+  chapter?: string;
+  /** Course: an example anchor to scroll to (from a Glossary "used in" link). */
+  ex?: string;
+  /** UI language. Always present once normalized. */
+  lang: Lang;
+}
+
+/** Patch passed to navigate() — every field optional, merged onto the current route. */
+export type RoutePatch = Partial<Route>;
+
+interface RouteCtx {
+  route: Route;
+  navigate: (patch: RoutePatch, opts?: { replace?: boolean }) => void;
+}
+
+const Ctx = createContext<RouteCtx | null>(null);
+const LANG_KEY = "tj-lang";
+
+// tab <-> url segment (the URL says "course"/"foundations"; code says the tab id)
+const TAB_TO_SEG: Record<Tab, string> = {
+  concepts: "foundations",
+  tutorial: "course",
+  glossary: "glossary",
+  playground: "playground",
+};
+const SEG_TO_TAB: Record<string, Tab> = {
+  foundations: "concepts",
+  course: "tutorial",
+  glossary: "glossary",
+  playground: "playground",
+};
+
+function storedLang(): Lang {
+  if (typeof localStorage !== "undefined") {
+    const v = localStorage.getItem(LANG_KEY);
+    if (v === "en" || v === "zh") return v;
+  }
+  return "en";
+}
+
+function parseHash(hash: string): Route {
+  const raw = hash.replace(/^#\/?/, "");
+  const [path = "", qs] = raw.split("?");
+  const segs = path.split("/").filter(Boolean);
+  const tab = SEG_TO_TAB[segs[0] ?? ""] ?? "concepts";
+  const params = new URLSearchParams(qs ?? "");
+  const langParam = params.get("lang");
+  const lang: Lang =
+    langParam === "zh" || langParam === "en" ? langParam : storedLang();
+
+  const route: Route = { tab, lang };
+  const sub = segs[1];
+  if (tab === "concepts" && sub) route.article = decodeURIComponent(sub);
+  if (tab === "tutorial" && sub) route.chapter = decodeURIComponent(sub);
+  const ex = params.get("ex");
+  if (ex && tab === "tutorial") route.ex = ex;
+  return route;
+}
+
+function formatHash(r: Route): string {
+  const segs = [TAB_TO_SEG[r.tab]];
+  if (r.tab === "concepts" && r.article) segs.push(encodeURIComponent(r.article));
+  if (r.tab === "tutorial" && r.chapter) segs.push(encodeURIComponent(r.chapter));
+  const params = new URLSearchParams();
+  if (r.tab === "tutorial" && r.ex) params.set("ex", r.ex);
+  if (r.lang) params.set("lang", r.lang);
+  const qs = params.toString();
+  return `#/${segs.join("/")}${qs ? `?${qs}` : ""}`;
+}
+
+export function RouteProvider({ children }: { children: ReactNode }) {
+  const [route, setRoute] = useState<Route>(() =>
+    parseHash(typeof location !== "undefined" ? location.hash : "")
+  );
+  const ref = useRef(route);
+  ref.current = route;
+
+  // Normalize the URL on first load so it always reflects the full state.
+  useEffect(() => {
+    const normalized = formatHash(ref.current);
+    if (location.hash !== normalized) {
+      history.replaceState(null, "", normalized);
+    }
+    const onChange = () => setRoute(parseHash(location.hash));
+    window.addEventListener("hashchange", onChange);
+    return () => window.removeEventListener("hashchange", onChange);
+  }, []);
+
+  const navigate = useCallback(
+    (patch: RoutePatch, opts?: { replace?: boolean }) => {
+      const prev = ref.current;
+      const tabChanged = patch.tab !== undefined && patch.tab !== prev.tab;
+      const next: Route = { ...prev, ...patch };
+      // Switching section drops the other sections' sub-targets unless the patch
+      // explicitly sets them.
+      if (tabChanged) {
+        if (!("article" in patch)) next.article = undefined;
+        if (!("chapter" in patch)) next.chapter = undefined;
+        if (!("ex" in patch)) next.ex = undefined;
+      }
+      const h = formatHash(next);
+      if (h === location.hash) {
+        setRoute(next); // hash identical (e.g. clearing ex) — sync state directly
+        return;
+      }
+      if (opts?.replace) {
+        history.replaceState(null, "", h);
+        setRoute(next);
+      } else {
+        location.hash = h; // pushes a history entry; hashchange updates state
+      }
+    },
+    []
+  );
+
+  return <Ctx.Provider value={{ route, navigate }}>{children}</Ctx.Provider>;
+}
+
+export function useRoute(): RouteCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("useRoute must be used within RouteProvider");
+  return ctx;
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -2,16 +2,19 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./monaco-setup"; // self-host Monaco + workers before anything renders
 import App from "./App";
+import { RouteProvider } from "./context/route";
 import { LangProvider } from "./context/lang";
 import { ThemeProvider } from "./context/theme";
 import "./theme.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ThemeProvider>
-      <LangProvider>
-        <App />
-      </LangProvider>
-    </ThemeProvider>
+    <RouteProvider>
+      <ThemeProvider>
+        <LangProvider>
+          <App />
+        </LangProvider>
+      </ThemeProvider>
+    </RouteProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Builds on #26. Two pieces.

## 1. Native hash routing (Back / Forward + shareable links)

The URL is now the single source of truth for navigation.

- New `context/route.tsx` — hash router: `#/foundations/architecture`, `#/course/e01?ex=…&lang=zh`. Hash routing needs no server rewrite, so it works as-is on GitHub Pages.
- **Navigable with Back/Forward**: tab, selected chapter, selected article, the Glossary→example jump (URL self-cleans the `ex` after scrolling), Foundations→chapter deep-links, and the **EN/中文** language toggle.
- Language moved into the route (`lang.tsx` derives from it); localStorage still restores the last pick on a fresh visit.
- Dropped the prop-drilling: Tutorial / Glossary / Concepts read the route directly via `navigate()` instead of `jump` / `focusChapter` / `onNavigate` callbacks.

## 2. Foundations primer, rewritten

A from-scratch rewrite aimed at a zero-background reader, taught like a programming language.

- **Method**: every structural idea shown three ways — Japanese, English, and a small piece of lightweight TypeScript — with **per-language comments** and a dependency-free **syntax highlighter**.
- **Spine is the function idea**: a clause is a verb applied to tagged arguments, *verb last*, and sentences **nest** those calls (relative clauses, quotation). The term **節 (clause)** is defined before it's used.
- **Composition diagrams** (new `diagram` block — nested clause-boxes, plus a flat row for morphology) on **every principle** and on a complex **capstone** sentence decomposed layer by layer.
- Removed the 🏛️ emoji and the "one hour" framing. Tagline: **把日语语法当成一门编程语言来读 / Read Japanese grammar like a programming language.**

## Verification
- root `tsc` ✓ · playground `tsc` ✓ · `vite build` ✓ · `verify:snippets` (382) ✓ · `verify:vocab` ✓ · all article deep-links resolve ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
