### PR TITLE
feat: default to Grammar Course; first chapter points to Foundations

### DIFF
--- a/playground/src/components/Tutorial.module.css
+++ b/playground/src/components/Tutorial.module.css
@@ -115,6 +115,47 @@
   max-width: 70ch;
 }
 
+/* pointer to the Foundations primer, shown on the very first chapter */
+.foundationsNote {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 16px;
+  width: 100%;
+  max-width: 72ch;
+  margin: 18px 0 4px;
+  padding: 13px 16px;
+  text-align: left;
+  cursor: pointer;
+  background: var(--sakura-50);
+  border: 1px solid var(--border-strong);
+  border-left: 4px solid var(--sakura-400);
+  border-radius: var(--radius-sm);
+  transition: background 0.12s, border-color 0.12s, transform 0.12s;
+}
+
+.foundationsNote:hover {
+  background: var(--sakura-100);
+  border-color: var(--sakura-400);
+  transform: translateY(-1px);
+}
+
+.foundationsNoteText {
+  flex: 1 1 22ch;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--ink-700);
+}
+
+.foundationsNoteCta {
+  flex: none;
+  font-size: 0.88rem;
+  font-weight: 700;
+  white-space: nowrap;
+  color: var(--sakura-600);
+}
+
 .point {
   margin: 26px 0;
   padding-top: 18px;

--- a/playground/src/components/Tutorial.tsx
+++ b/playground/src/components/Tutorial.tsx
@@ -160,6 +160,26 @@ export default function Tutorial() {
               <p className={styles.chapterSummary}>{t(active.summaryEn, active.summaryZh)}</p>
             </header>
 
+            {active.id === CHAPTERS[0]?.id && (
+              <button
+                type="button"
+                className={styles.foundationsNote}
+                onClick={() =>
+                  navigate({ tab: "concepts", article: "architecture" })
+                }
+              >
+                <span className={styles.foundationsNoteText}>
+                  {t(
+                    "New to Japanese? Read the Foundations primer first — it shows how a sentence is built, the way you'd learn a programming language.",
+                    "刚接触日语？建议先读一遍《原理》—— 它会像学编程语言那样，讲清楚一句日语是怎么搭起来的。"
+                  )}
+                </span>
+                <span className={styles.foundationsNoteCta}>
+                  {t("Open Foundations", "打开原理")} →
+                </span>
+              </button>
+            )}
+
             {active.points.map((pt) => (
               <section key={pt.id} className={styles.point}>
                 <h3 className={styles.pointTitle}>{t(pt.titleEn, pt.titleZh)}</h3>

--- a/playground/src/context/route.tsx
+++ b/playground/src/context/route.tsx
@@ -74,7 +74,8 @@ function parseHash(hash: string): Route {
   const raw = hash.replace(/^#\/?/, "");
   const [path = "", qs] = raw.split("?");
   const segs = path.split("/").filter(Boolean);
-  const tab = SEG_TO_TAB[segs[0] ?? ""] ?? "concepts";
+  // Default landing is the Grammar Course; the first chapter points to Foundations.
+  const tab = SEG_TO_TAB[segs[0] ?? ""] ?? "tutorial";
   const params = new URLSearchParams(qs ?? "");
   const langParam = params.get("lang");
   const lang: Lang =


### PR DESCRIPTION
Two small UX changes, then auto-deploys to GitHub Pages.

- **Default landing is now the Grammar Course** (`#/course`) instead of Foundations — visitors arrive directly in the lessons.
- **The first chapter opens with a pointer to the Foundations primer**: a callout under the chapter summary that deep-links to `#/foundations/architecture`, so newcomers still find the "how a sentence is built" overview first.

Foundations stays the first tab and fully reachable; only the default selection changed.

## Verification
- playground `tsc` ✓ · `vite build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
