### PR TITLE
feat(seo): prerender to static HTML — real URLs, meta, sitemap, JSON-LD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
 dist
+dist-server
 *.tsbuildinfo

--- a/playground/index.html
+++ b/playground/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
     <title>Typed Japanese Playground</title>
+    <!--app-head-->
     <!-- Tutorial type: textbook feel in LXGW WenKai Screen (霞鹜文楷, 楷体),
          which covers CN + JP. Noto Serif SC/JP are the fallbacks. The webfont
          is unicode-range split, so only the glyphs on screen get downloaded. -->
@@ -41,7 +42,7 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div id="root"><!--app-html--></div>
+    <script type="module" src="/src/entry-client.tsx"></script>
   </body>
 </html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node scripts/gen-reverse-index.mjs && vite",
-    "build": "node scripts/gen-reverse-index.mjs && tsc -b && vite build",
+    "build": "node scripts/gen-reverse-index.mjs && tsc -b && vite build && vite build --ssr src/entry-server.tsx --outDir dist-server && node scripts/prerender.mjs",
     "gen:reverse-index": "node scripts/gen-reverse-index.mjs",
     "preview": "vite preview",
     "typecheck": "node scripts/gen-reverse-index.mjs && tsc --noEmit",

--- a/playground/scripts/prerender.mjs
+++ b/playground/scripts/prerender.mjs
@@ -1,0 +1,113 @@
+/**
+ * Static-site generation. Runs after the client build (dist/) and the SSR build
+ * (dist-server/entry-server.js). For every route returned by getRoutes() it:
+ *   1. server-renders the React app to HTML,
+ *   2. injects per-page <title>, meta, canonical, hreflang, Open Graph + JSON-LD,
+ *   3. writes dist/<lang>/<section>/<sub>/index.html.
+ * Then it emits sitemap.xml, robots.txt, and a 404.html SPA fallback.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const DIST = path.join(ROOT, "dist");
+const BASE = process.env.VITE_BASE || "/typed-japanese/";
+const ORIGIN = process.env.SITE_ORIGIN || "https://typedgrammar.github.io";
+
+const template = fs.readFileSync(path.join(DIST, "index.html"), "utf8");
+const { render, getRoutes } = await import(
+  pathToFileURL(path.join(ROOT, "dist-server", "entry-server.js")).href
+);
+
+const esc = (s) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+function headFor(meta) {
+  const ogType = meta.path.includes("/foundations/") ? "article" : "website";
+  const tags = [
+    `<meta name="description" content="${esc(meta.description)}" />`,
+    `<link rel="canonical" href="${esc(meta.canonical)}" />`,
+    ...meta.alternates.map(
+      (a) =>
+        `<link rel="alternate" hreflang="${a.hreflang}" href="${esc(a.href)}" />`
+    ),
+    `<meta property="og:type" content="${ogType}" />`,
+    `<meta property="og:title" content="${esc(meta.title)}" />`,
+    `<meta property="og:description" content="${esc(meta.description)}" />`,
+    `<meta property="og:url" content="${esc(meta.canonical)}" />`,
+    `<meta property="og:site_name" content="Typed Japanese" />`,
+    `<meta property="og:locale" content="${meta.lang === "zh" ? "zh_CN" : "en_US"}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${esc(meta.title)}" />`,
+    `<meta name="twitter:description" content="${esc(meta.description)}" />`,
+    `<script type="application/ld+json">${JSON.stringify(meta.jsonld)}</script>`,
+  ];
+  return tags.join("\n    ");
+}
+
+function pageHtml(meta, appHtml) {
+  return template
+    .replace('<html lang="ja">', `<html lang="${meta.lang}">`)
+    .replace(/<title>[^<]*<\/title>/, `<title>${esc(meta.title)}</title>`)
+    .replace("<!--app-head-->", headFor(meta))
+    .replace("<!--app-html-->", appHtml);
+}
+
+const routes = getRoutes();
+let written = 0;
+for (const meta of routes) {
+  const { html } = render(meta.path);
+  const rel = meta.path.slice(BASE.length).replace(/\/$/, ""); // en/course/e01
+  const dir = path.join(DIST, rel);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "index.html"), pageHtml(meta, html));
+  written++;
+}
+
+// Root: serve the English course as the landing page, canonical → /en/course/.
+const rootMeta = routes.find((r) => r.path === `${BASE}en/course/`);
+if (rootMeta) {
+  const { html } = render(rootMeta.path);
+  fs.writeFileSync(path.join(DIST, "index.html"), pageHtml(rootMeta, html));
+}
+
+// sitemap.xml (with hreflang alternates per URL)
+const urlEntries = routes
+  .map((r) => {
+    const links = r.alternates
+      .filter((a) => a.hreflang !== "x-default")
+      .map(
+        (a) =>
+          `    <xhtml:link rel="alternate" hreflang="${a.hreflang}" href="${esc(a.href)}" />`
+      )
+      .join("\n");
+    return `  <url>\n    <loc>${esc(r.canonical)}</loc>\n${links}\n  </url>`;
+  })
+  .join("\n");
+fs.writeFileSync(
+  path.join(DIST, "sitemap.xml"),
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">\n${urlEntries}\n</urlset>\n`
+);
+
+// robots.txt
+fs.writeFileSync(
+  path.join(DIST, "robots.txt"),
+  `User-agent: *\nAllow: /\nSitemap: ${ORIGIN}${BASE}sitemap.xml\n`
+);
+
+// 404.html — GitHub Pages SPA fallback for any non-prerendered path; the client
+// reads location and renders the right route.
+fs.writeFileSync(
+  path.join(DIST, "404.html"),
+  template.replace("<!--app-head-->", "").replace("<!--app-html-->", "")
+);
+
+console.log(
+  `Prerendered ${written} pages + index, sitemap.xml (${routes.length} URLs), robots.txt, 404.html.`
+);

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,11 +1,14 @@
+import { lazy, Suspense, useEffect, useState } from "react";
 import Concepts from "./components/Concepts";
 import Tutorial from "./components/Tutorial";
 import Playground from "./components/Playground";
 import Glossary from "./components/Glossary";
-import FontLab from "./components/FontLab";
 import { useLang } from "./context/lang";
 import { useTheme } from "./context/theme";
 import { useRoute } from "./context/route";
+
+// Client-only floating font panel — kept out of the server prerender.
+const FontLab = lazy(() => import("./components/FontLab"));
 
 const TAB_BASE =
   "inline-flex items-center gap-[7px] px-[18px] py-[9px] border rounded-full cursor-pointer text-[0.9rem] font-bold transition-all duration-[140ms]";
@@ -26,6 +29,9 @@ export default function App() {
   const { theme, toggleTheme } = useTheme();
   const { route, navigate } = useRoute();
   const tab = route.tab;
+  // Mount the client-only font panel after hydration (never during prerender).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   return (
     <div className="flex flex-col min-h-full max-w-[1280px] mx-auto px-5">
@@ -145,7 +151,11 @@ export default function App() {
         )}
       </footer>
 
-      <FontLab />
+      {mounted && (
+        <Suspense fallback={null}>
+          <FontLab />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/playground/src/components/Playground.tsx
+++ b/playground/src/components/Playground.tsx
@@ -1,6 +1,9 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { SNIPPETS } from "../data/examples";
-import Analyzer from "./Analyzer";
+
+// Monaco (and the whole Analyzer) is client-only and heavy — load it lazily so
+// it is never pulled into the server prerender.
+const Analyzer = lazy(() => import("./Analyzer"));
 
 export default function Playground() {
   const [index, setIndex] = useState(0);
@@ -24,7 +27,11 @@ export default function Playground() {
         </div>
       </div>
 
-      <Analyzer code={active.code} gloss={active.en} />
+      <Suspense
+        fallback={<p className="tj-subtle">Loading the analyzer…</p>}
+      >
+        <Analyzer code={active.code} gloss={active.en} />
+      </Suspense>
 
       <p className="tj-subtle text-center m-0">
         Edit the code — the structure re-parses live. Click any node to highlight

--- a/playground/src/components/Tutorial.tsx
+++ b/playground/src/components/Tutorial.tsx
@@ -1,4 +1,6 @@
 import {
+  lazy,
+  Suspense,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -12,9 +14,16 @@ import { exampleAnchorId, type Chapter, type Example, type Level } from "../tuto
 import { useLang } from "../context/lang";
 import { useRoute } from "../context/route";
 import { extractWords } from "../vocab/extract";
-import Analyzer from "./Analyzer";
 import VocabWord from "./VocabWord";
 import styles from "./Tutorial.module.css";
+
+// Monaco-backed; lazy so it stays out of the server prerender.
+const Analyzer = lazy(() => import("./Analyzer"));
+
+// Layout effects don't run on the server; fall back to useEffect there to avoid
+// the SSR warning (this effect is client-only — it scrolls/flashes an example).
+const useIsoLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 const LEVELS: Level[] = ["elementary", "intermediate", "advanced"];
 
@@ -64,7 +73,7 @@ export default function Tutorial() {
 
   // After the target chapter has rendered, scroll the example into view and
   // flash it. Runs after every render until the anchor element exists.
-  useLayoutEffect(() => {
+  useIsoLayoutEffect(() => {
     const anchor = pendingAnchor.current;
     if (!anchor) return;
     const el = document.getElementById(anchor);
@@ -248,10 +257,12 @@ export default function Tutorial() {
         </div>
         <div className="flex-1 overflow-auto p-4">
           {drawerExample && (
-            <Analyzer
-              code={drawerExample.code}
-              gloss={lang === "zh" ? drawerExample.zh : drawerExample.en}
-            />
+            <Suspense fallback={<p className="tj-subtle">Loading…</p>}>
+              <Analyzer
+                code={drawerExample.code}
+                gloss={lang === "zh" ? drawerExample.zh : drawerExample.en}
+              />
+            </Suspense>
           )}
         </div>
       </aside>

--- a/playground/src/context/route.tsx
+++ b/playground/src/context/route.tsx
@@ -1,16 +1,16 @@
 /**
- * Hash-based routing — the URL is the single source of truth for navigation, so
- * tab switches, cross-section jumps (Glossary → example, Foundations → chapter),
- * the selected chapter/article, and the UI language all work with the browser's
- * Back / Forward buttons and are shareable as links.
+ * Path-based routing (History API). The URL is the single source of truth, so
+ * every section, chapter/article, and the UI language is a real, crawlable URL
+ * with Back/Forward support — which is what lets the site be prerendered to
+ * static HTML per page for SEO.
  *
- * Hash shape:  #/<section>[/<sub>]?ex=<anchor>&lang=<en|zh>
- *   #/foundations            #/foundations/architecture
- *   #/course                 #/course/e01           #/course/e01?ex=ex-e01-e01-2-0
- *   #/glossary               #/playground
+ * URL shape:  <base>/<lang>/<section>[/<sub>][/?ex=<anchor>]
+ *   /en/course            /en/course/e01            /en/course/e01/?ex=ex-e01-…
+ *   /zh/foundations       /zh/foundations/architecture
+ *   /en/glossary          /en/playground
  *
- * Hash routing (not the History API) is deliberate: it needs no server rewrite,
- * so it works as-is on GitHub Pages.
+ * `<base>` is Vite's BASE_URL (e.g. "/typed-japanese/"). The provider accepts an
+ * `ssrPath` so the prerenderer can render any route on the server with no DOM.
  */
 import {
   createContext,
@@ -33,11 +33,10 @@ export interface Route {
   chapter?: string;
   /** Course: an example anchor to scroll to (from a Glossary "used in" link). */
   ex?: string;
-  /** UI language. Always present once normalized. */
+  /** UI language — also the first URL segment. */
   lang: Lang;
 }
 
-/** Patch passed to navigate() — every field optional, merged onto the current route. */
 export type RoutePatch = Partial<Route>;
 
 interface RouteCtx {
@@ -46,9 +45,8 @@ interface RouteCtx {
 }
 
 const Ctx = createContext<RouteCtx | null>(null);
-const LANG_KEY = "tj-lang";
+const BASE = import.meta.env.BASE_URL || "/";
 
-// tab <-> url segment (the URL says "course"/"foundations"; code says the tab id)
 const TAB_TO_SEG: Record<Tab, string> = {
   concepts: "foundations",
   tutorial: "course",
@@ -62,61 +60,76 @@ const SEG_TO_TAB: Record<string, Tab> = {
   playground: "playground",
 };
 
-function storedLang(): Lang {
-  if (typeof localStorage !== "undefined") {
-    const v = localStorage.getItem(LANG_KEY);
-    if (v === "en" || v === "zh") return v;
-  }
-  return "en";
-}
+export const LANGS: Lang[] = ["en", "zh"];
 
-function parseHash(hash: string): Route {
-  const raw = hash.replace(/^#\/?/, "");
-  const [path = "", qs] = raw.split("?");
-  const segs = path.split("/").filter(Boolean);
-  // Default landing is the Grammar Course; the first chapter points to Foundations.
-  const tab = SEG_TO_TAB[segs[0] ?? ""] ?? "tutorial";
-  const params = new URLSearchParams(qs ?? "");
-  const langParam = params.get("lang");
-  const lang: Lang =
-    langParam === "zh" || langParam === "en" ? langParam : storedLang();
+/**
+ * Parse a full href (pathname[?search]) into a Route. Pure and deterministic
+ * (no localStorage) so the server prerender and the client agree on hydration —
+ * the language lives in the URL. A path with no language segment defaults to en.
+ */
+export function parseHref(href: string): Route {
+  const [rawPath = "/", search = ""] = href.split("?");
+  let p = rawPath;
+  const baseNoSlash = BASE.replace(/\/$/, "");
+  if (baseNoSlash && p.startsWith(baseNoSlash)) p = p.slice(baseNoSlash.length);
+  const segs = p.split("/").filter(Boolean);
+
+  let i = 0;
+  let lang: Lang = "en";
+  if (segs[0] === "en" || segs[0] === "zh") {
+    lang = segs[0];
+    i = 1;
+  }
+  const tab = SEG_TO_TAB[segs[i] ?? ""] ?? "tutorial";
+  const sub = segs[i + 1];
 
   const route: Route = { tab, lang };
-  const sub = segs[1];
   if (tab === "concepts" && sub) route.article = decodeURIComponent(sub);
   if (tab === "tutorial" && sub) route.chapter = decodeURIComponent(sub);
-  const ex = params.get("ex");
+  const ex = new URLSearchParams(search).get("ex");
   if (ex && tab === "tutorial") route.ex = ex;
   return route;
 }
 
-function formatHash(r: Route): string {
-  const segs = [TAB_TO_SEG[r.tab]];
+/** Canonical URL (with base + trailing slash) for a route. */
+export function formatPath(r: Route): string {
+  const segs = [r.lang, TAB_TO_SEG[r.tab]];
   if (r.tab === "concepts" && r.article) segs.push(encodeURIComponent(r.article));
   if (r.tab === "tutorial" && r.chapter) segs.push(encodeURIComponent(r.chapter));
-  const params = new URLSearchParams();
-  if (r.tab === "tutorial" && r.ex) params.set("ex", r.ex);
-  if (r.lang) params.set("lang", r.lang);
-  const qs = params.toString();
-  return `#/${segs.join("/")}${qs ? `?${qs}` : ""}`;
+  const qs = r.tab === "tutorial" && r.ex ? `?ex=${encodeURIComponent(r.ex)}` : "";
+  return `${BASE}${segs.join("/")}/${qs}`;
 }
 
-export function RouteProvider({ children }: { children: ReactNode }) {
+export function RouteProvider({
+  children,
+  ssrPath,
+}: {
+  children: ReactNode;
+  /** Render-target path on the server; client reads location instead. */
+  ssrPath?: string;
+}) {
   const [route, setRoute] = useState<Route>(() =>
-    parseHash(typeof location !== "undefined" ? location.hash : "")
+    parseHref(
+      ssrPath ??
+        (typeof location !== "undefined"
+          ? location.pathname + location.search
+          : "/")
+    )
   );
   const ref = useRef(route);
   ref.current = route;
 
-  // Normalize the URL on first load so it always reflects the full state.
+  // Normalize the URL on first client load (e.g. "/" → "/en/course/") and keep
+  // state in sync with Back/Forward.
   useEffect(() => {
-    const normalized = formatHash(ref.current);
-    if (location.hash !== normalized) {
-      history.replaceState(null, "", normalized);
+    const canonical = formatPath(ref.current);
+    if (location.pathname + location.search !== canonical) {
+      history.replaceState(null, "", canonical);
     }
-    const onChange = () => setRoute(parseHash(location.hash));
-    window.addEventListener("hashchange", onChange);
-    return () => window.removeEventListener("hashchange", onChange);
+    const onPop = () =>
+      setRoute(parseHref(location.pathname + location.search));
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
   }, []);
 
   const navigate = useCallback(
@@ -124,23 +137,24 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       const prev = ref.current;
       const tabChanged = patch.tab !== undefined && patch.tab !== prev.tab;
       const next: Route = { ...prev, ...patch };
-      // Switching section drops the other sections' sub-targets unless the patch
-      // explicitly sets them.
       if (tabChanged) {
         if (!("article" in patch)) next.article = undefined;
         if (!("chapter" in patch)) next.chapter = undefined;
         if (!("ex" in patch)) next.ex = undefined;
       }
-      const h = formatHash(next);
-      if (h === location.hash) {
-        setRoute(next); // hash identical (e.g. clearing ex) — sync state directly
-        return;
-      }
-      if (opts?.replace) {
-        history.replaceState(null, "", h);
-        setRoute(next);
+      const url = formatPath(next);
+      if (typeof window !== "undefined") {
+        if (url === location.pathname + location.search) {
+          setRoute(next);
+        } else if (opts?.replace) {
+          history.replaceState(null, "", url);
+          setRoute(next);
+        } else {
+          history.pushState(null, "", url);
+          setRoute(next);
+        }
       } else {
-        location.hash = h; // pushes a history entry; hashchange updates state
+        setRoute(next);
       }
     },
     []

--- a/playground/src/entry-client.tsx
+++ b/playground/src/entry-client.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import "./monaco-setup"; // self-host Monaco + workers before anything renders
 import App from "./App";
 import { RouteProvider } from "./context/route";
@@ -7,7 +7,7 @@ import { LangProvider } from "./context/lang";
 import { ThemeProvider } from "./context/theme";
 import "./theme.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const tree = (
   <React.StrictMode>
     <RouteProvider>
       <ThemeProvider>
@@ -18,3 +18,12 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     </RouteProvider>
   </React.StrictMode>
 );
+
+const root = document.getElementById("root")!;
+// Production HTML is prerendered (has element children) → hydrate.
+// Dev serves an empty shell → fresh render.
+if (root.firstElementChild) {
+  hydrateRoot(root, tree);
+} else {
+  createRoot(root).render(tree);
+}

--- a/playground/src/entry-server.tsx
+++ b/playground/src/entry-server.tsx
@@ -1,0 +1,161 @@
+import { renderToString } from "react-dom/server";
+import App from "./App";
+import { RouteProvider, formatPath, LANGS, type Lang, type Route } from "./context/route";
+import { LangProvider } from "./context/lang";
+import { ThemeProvider } from "./context/theme";
+import { CHAPTERS } from "./tutorial/chapters";
+import { ARTICLES } from "./concepts";
+import { VOCAB_LIST } from "./vocab/dictionary";
+
+/** Public origin for canonical / sitemap URLs (override with VITE_SITE_ORIGIN). */
+const ORIGIN =
+  import.meta.env.VITE_SITE_ORIGIN || "https://typedgrammar.github.io";
+const BRAND = "Typed Japanese";
+
+/**
+ * Render the app for one route to an HTML string. No DOM, no Monaco (the
+ * Analyzer is lazy and absent from the initial tree).
+ */
+export function render(path: string): { html: string } {
+  const html = renderToString(
+    <RouteProvider ssrPath={path}>
+      <ThemeProvider>
+        <LangProvider>
+          <App />
+        </LangProvider>
+      </ThemeProvider>
+    </RouteProvider>
+  );
+  return { html };
+}
+
+/** Strip markdown/whitespace and clamp for a meta description. */
+function metaText(s: string, max = 155): string {
+  const clean = s
+    .replace(/`+/g, "")
+    .replace(/\*\*/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return clean.length > max ? clean.slice(0, max - 1).trimEnd() + "…" : clean;
+}
+
+export interface RouteMeta {
+  /** Canonical path incl. base + trailing slash, e.g. /typed-japanese/en/course/e01/ */
+  path: string;
+  lang: Lang;
+  title: string;
+  description: string;
+  /** Absolute canonical URL. */
+  canonical: string;
+  /** hreflang alternates (one per language) + x-default. */
+  alternates: { hreflang: string; href: string }[];
+  /** schema.org JSON-LD object. */
+  jsonld: Record<string, unknown>;
+}
+
+/** Every prerendered page, with its SEO metadata, both languages. */
+export function getRoutes(): RouteMeta[] {
+  const out: RouteMeta[] = [];
+
+  const make = (
+    partial: Omit<Route, "lang">,
+    titles: { en: string; zh: string },
+    descs: { en: string; zh: string },
+    schemaType: string
+  ) => {
+    for (const lang of LANGS) {
+      const route: Route = { ...partial, lang };
+      const path = formatPath(route);
+      const title = `${lang === "zh" ? titles.zh : titles.en} · ${BRAND}`;
+      const description = metaText(lang === "zh" ? descs.zh : descs.en);
+      const canonical = ORIGIN + path;
+      const alternates: { hreflang: string; href: string }[] = LANGS.map(
+        (l) => ({
+          hreflang: l as string,
+          href: ORIGIN + formatPath({ ...route, lang: l }),
+        })
+      );
+      alternates.push({
+        hreflang: "x-default",
+        href: ORIGIN + formatPath({ ...route, lang: "en" }),
+      });
+      out.push({
+        path,
+        lang,
+        title,
+        description,
+        canonical,
+        alternates,
+        jsonld: {
+          "@context": "https://schema.org",
+          "@type": schemaType,
+          name: lang === "zh" ? titles.zh : titles.en,
+          description,
+          inLanguage: lang,
+          url: canonical,
+          isPartOf: { "@type": "Course", name: BRAND, url: ORIGIN + "/typed-japanese/" },
+        },
+      });
+    }
+  };
+
+  // Section landing pages
+  make(
+    { tab: "tutorial" },
+    { en: "Grammar Course", zh: "语法教程" },
+    {
+      en: "A 47-chapter Japanese grammar course where every sentence is a TypeScript type the compiler checks.",
+      zh: "47 章日语语法课程，每个句子都是 TypeScript 编译器可校验的类型。",
+    },
+    "Course"
+  );
+  make(
+    { tab: "concepts" },
+    { en: "Foundations", zh: "原理" },
+    {
+      en: "The architecture of Japanese, taught like a programming language — particles, word order, predicates, conjugation.",
+      zh: "像学编程语言一样理解日语的架构 —— 助词、语序、谓语、活用。",
+    },
+    "LearningResource"
+  );
+  make(
+    { tab: "glossary" },
+    { en: "Glossary", zh: "词汇表" },
+    {
+      en: `Every word used in the course — ${VOCAB_LIST.length} entries with readings, romaji and meanings, cross-linked to the sentences that use them.`,
+      zh: `课程用到的全部词语 —— ${VOCAB_LIST.length} 条，含读音、罗马字与释义，并反向链接到使用它们的句子。`,
+    },
+    "DefinedTermSet"
+  );
+  make(
+    { tab: "playground" },
+    { en: "Playground", zh: "演练场" },
+    {
+      en: "An interactive playground: write a Japanese sentence as a TypeScript type and watch the compiler resolve and visualise its structure.",
+      zh: "交互式演练场：把日语句子写成 TypeScript 类型，看编译器求值并可视化它的结构。",
+    },
+    "WebApplication"
+  );
+
+  // Course chapters
+  for (const c of CHAPTERS) {
+    make(
+      { tab: "tutorial", chapter: c.id },
+      { en: c.titleEn, zh: c.titleZh },
+      { en: c.summaryEn, zh: c.summaryZh },
+      "LearningResource"
+    );
+  }
+
+  // Foundations articles
+  for (const a of ARTICLES) {
+    make(
+      { tab: "concepts", article: a.id },
+      { en: a.titleEn, zh: a.titleZh },
+      { en: a.taglineEn, zh: a.taglineZh },
+      "Article"
+    );
+  }
+
+  return out;
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -7,9 +7,10 @@ import tailwindcss from "@tailwindcss/vite";
 // them as extra libs and type-check real Typed Japanese code in the browser.
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  // Deployed under a subpath on GitHub Pages; relative base keeps assets working
-  // both there and on StackBlitz / local preview.
-  base: "./",
+  // Absolute base (not "./") so prerendered pages in nested directories
+  // (e.g. /en/course/e01/) resolve hashed assets correctly. Override via
+  // VITE_BASE for a different mount point (e.g. the future /learn/japanese/).
+  base: process.env.VITE_BASE ?? "/typed-japanese/",
   server: {
     fs: {
       // Allow importing the .d.ts sources from the parent package.


### PR DESCRIPTION
Turns the client-rendered SPA — one empty-shell URL, no metadata, hash routing — into a **fully prerendered static site**, so the whole 47-chapter course is crawlable.

## Before → after
| | before | after |
|---|---|---|
| HTML a crawler gets | 2 KB empty shell | **~45 KB real content** per page |
| URLs | 1 (hash `#/…`) | **104 path URLs** (52 routes × en/zh) |
| `<title>` / description / OG | one global / none | **per page** |
| sitemap / robots | 404 | **generated** |

## Routing
- Hash → **History API path routing**, language as the first segment: `/<lang>/<section>[/<sub>]/` (e.g. `/en/course/e01/`, `/zh/foundations/architecture/`). `parseHref` is pure/deterministic so SSR and client hydration agree. vite `base` is now absolute so nested pages resolve assets (overridable via `VITE_BASE`).

## Prerendering (SSG)
- Entry split into `entry-client` (hydrate-or-render) and `entry-server` (`renderToString` + `getRoutes()`, which derives every page and its SEO metadata from the chapter/article/vocab data). `scripts/prerender.mjs` writes all pages to `dist/<lang>/<section>/<sub>/index.html`.
- Monaco/Analyzer and the FontLab panel are **lazy + client-only**, so the server tree pulls no DOM/Monaco; Tutorial's layout effect is isomorphic.

## Per-page SEO
- Real content in HTML · per-page `<title>` · `<meta description>` (chapter summary) · canonical · **hreflang** (en/zh/x-default) · Open Graph + Twitter cards · schema.org **JSON-LD**.
- Generated **sitemap.xml** (104 URLs with hreflang), **robots.txt**, and a **404.html** SPA fallback for GitHub Pages.

## Verification
- `tsc` · `vite build` + SSR build + prerender (104 pages) · `verify:snippets` (382) · `verify:vocab` — all green. JSON-LD parses; nested pages reference absolute `/typed-japanese/assets/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
