### PR TITLE
feat(playground): AI annotate workflow — Japanese → verified Typed Japanese

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -39,7 +39,7 @@ The analyzer screen has two halves:
   itself** (resolved through Monaco's worker). Click any node to highlight the
   source it came from.
 
-So `ConditionalPhrase<ヒンメル, "なら", DemonstrativeAction<"そう", する, "た形">>`
+So `ConditionalPhrase<ヒンメル, "なら", DemonstrativeAction<"そう", する, "Ta">>`
 becomes a tree you can read top-down to understand exactly how the sentence
 `ヒンメルならそうした` is built.
 
@@ -55,6 +55,38 @@ becomes a tree you can read top-down to understand exactly how the sentence
    instantiated string literal (e.g. `"そうした"`) — the real type-level result.
 3. **Render** — `src/components/CompositionTree.tsx` draws the indented,
    color-coded tree; selecting a node maps its source span back into the editor.
+
+## Generating snippets with AI (`bun run annotate`)
+
+Turn a plain Japanese sentence into a verified Typed Japanese snippet and drop it
+into the **✨ Generated** group of the Playground gallery:
+
+```bash
+bun run annotate "話して"
+bun run annotate "綺麗ですね" --title "Na-adjective" --retries 4
+bun run annotate "食べた" --dry-run        # verify + print, don't install
+```
+
+The workflow (`scripts/annotate.ts`) is the project's *"the type checker grades
+the LLM"* thesis as a tool:
+
+1. It prompts `codex exec` (default, via `--engine codex`) with a cheatsheet of
+   the library API and asks for a snippet whose **last `type` alias resolves to
+   exactly the input sentence** (returned as JSON: `code` / `en` / `title`).
+2. It **verifies** the snippet in-memory with the TypeScript Compiler API — it
+   must type-check against the real `../src` library *and* its last alias must
+   resolve to the input string. A second structure audit rejects `NounPhrase`
+   chunks, template-literal glue, particles hidden inside noun strings, and
+   leading/trailing whitespace inside technical terms.
+3. On failure it feeds the diagnostics back to the selected model and retries
+   (`--retries`, default 3). Use `--engine claude` to keep the old Claude CLI
+   path. Only a verified snippet is installed; on exhaustion it prints the best
+   attempt and writes nothing.
+
+Verified snippets are appended to `src/data/examples.generated.json` (typed and
+re-exported by `examples.generated.ts`), kept separate from the hand-curated
+`examples.ts`. Requires [Bun](https://bun.sh) and the Codex CLI on your `PATH`
+by default.
 
 ## Development
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,6 +7,7 @@
     "dev": "node scripts/gen-reverse-index.mjs && vite",
     "build": "node scripts/gen-reverse-index.mjs && tsc -b && vite build",
     "gen:reverse-index": "node scripts/gen-reverse-index.mjs",
+    "annotate": "bun scripts/annotate.ts",
     "preview": "vite preview",
     "typecheck": "node scripts/gen-reverse-index.mjs && tsc --noEmit",
     "verify:snippets": "node scripts/verify-snippets.mjs",

--- a/playground/scripts/annotate.ts
+++ b/playground/scripts/annotate.ts
@@ -1,0 +1,740 @@
+#!/usr/bin/env bun
+/**
+ * annotate — turn a Japanese sentence into a verified Typed Japanese snippet and
+ * install it into the playground gallery.
+ *
+ *   bun run annotate "話して"
+ *   bun run annotate "いいよ、来いよ" --title "Connected" --retries 4
+ *   bun scripts/annotate.ts "食べた" --model gpt-5 --dry-run
+ *   bun scripts/annotate.ts "食べた" --engine claude --model claude-sonnet-4-6 --dry-run
+ *
+ * Pipeline:
+ *   1. Load the live Typed Japanese library (../../src/*.d.ts) as the API the
+ *      model must target — so output tracks the real types, not a stale copy.
+ *   2. Ask `codex exec` (default) or `claude -p` for a snippet: a series of
+ *      `type` aliases whose LAST alias resolves to exactly the input sentence.
+ *      Output is a JSON {code,en,title}.
+ *   3. Verify in-memory with the TypeScript compiler: it must type-check AND its
+ *      last alias must resolve to the input string. A structure audit also
+ *      rejects NounPhrase/template-literal shortcuts that hide particles or
+ *      non-technical literals.
+ *   4. On failure, feed the diagnostics back to the model and retry (up to --retries).
+ *   5. On success, upsert the snippet into examples.generated.json; the playground
+ *      picks it up via examples.generated.ts. On exhaustion, print the best attempt
+ *      and its errors, write nothing, exit 1.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLAYGROUND = path.resolve(__dirname, "..");
+const REPO = path.resolve(PLAYGROUND, "..");
+const GEN_JSON = path.join(PLAYGROUND, "src/data/examples.generated.json");
+
+// Diagnostic codes the playground editor also suppresses ("declared but never
+// used" and friends) — a snippet is a sketch, unused aliases are expected.
+const IGNORE = new Set([6133, 6196, 6192, 6198, 6205]);
+
+// --- args --------------------------------------------------------------------
+
+interface Args {
+  sentence: string;
+  title?: string;
+  en?: string;
+  id?: string;
+  retries: number;
+  engine: "codex" | "claude";
+  model?: string;
+  dryRun: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { sentence: "", retries: 3, engine: "codex", dryRun: false, help: false };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    switch (a) {
+      case "--title": out.title = argv[++i]; break;
+      case "--en": out.en = argv[++i]; break;
+      case "--id": out.id = argv[++i]; break;
+      case "--retries": out.retries = Number(argv[++i]); break;
+      case "--engine": {
+        const engine = argv[++i];
+        if (engine !== "codex" && engine !== "claude") die(`--engine must be "codex" or "claude"`);
+        out.engine = engine;
+        break;
+      }
+      case "--model": out.model = argv[++i]; break;
+      case "--dry-run": out.dryRun = true; break;
+      case "-h":
+      case "--help": out.help = true; break;
+      default:
+        if (a.startsWith("--")) die(`Unknown flag: ${a}`);
+        positional.push(a);
+    }
+  }
+  out.sentence = positional.join(" ").trim();
+  if (!Number.isFinite(out.retries) || out.retries < 1) out.retries = 3;
+  return out;
+}
+
+function die(msg: string): never {
+  console.error(`\x1b[31m✗ ${msg}\x1b[0m`);
+  process.exit(1);
+}
+
+const USAGE = `Usage: bun run annotate "<日本語の文>" [options]
+
+  --title <s>     Gallery chip title (default: derived from the sentence)
+  --en <s>        English gloss override (default: from the model)
+  --id <s>        Stable id (default: derived; re-annotating a sentence updates it)
+  --retries <n>   Max attempts, errors fed back each time (default: 3)
+  --engine <s>    Model runner: codex or claude (default: codex)
+  --model <s>     Model passed through to the selected runner
+  --dry-run       Verify and print, but don't write to the gallery
+`;
+
+// --- library context ---------------------------------------------------------
+// A hand-curated cheatsheet of the public API. The full .d.ts is mostly internal
+// conjugation maps that only add noise; the model needs the exported signatures
+// and the (English) form-name unions. Verification (which loads the REAL ../src
+// via the paths mapping) is the source of truth, so this only has to be close.
+const API_REFERENCE = `# Verbs — verb-types
+GodanVerb    = { type:"godan";    stem:string; ending:"う"|"く"|"ぐ"|"す"|"つ"|"ぬ"|"ぶ"|"む"|"る" }
+IchidanVerb  = { type:"ichidan";  stem:string; ending:"る" }
+IrregularVerb= { type:"irregular"; dictionary:"する"|"来る"|"くる" }
+SuruVerb<Noun extends string> = a noun + する compound verb, e.g. SuruVerb<"勉強"> resolves as 勉強する
+ConjugateVerb<V extends Verb, F extends ConjugationForm>
+ConjugationForm = "Dictionary"|"Masu"|"Te"|"Ta"|"Nai"|"Potential"|"Passive"|"Causative"|"Volitional"|"Imperative"|"Conditional"|"Hypothetical"
+  // declare a verb as an intersection: type 話す = GodanVerb & { stem:"話"; ending:"す" };
+
+# Adjectives — adjective-types
+IAdjective  = { type:"i-adjective";  stem:string; ending:"い"; irregular?:boolean }
+NaAdjective = { type:"na-adjective"; stem:string }
+ConjugateAdjective<A extends Adjective, F extends AdjectiveConjugationForm>
+AdjectiveConjugationForm = "Basic"|"Polite"|"Past"|"Negative"|"Te"
+  // いい is irregular: type いい = IAdjective & { stem:"い"; ending:"い"; irregular:true };
+
+# Copula だ/です — copula-types (NOT a particle: it inflects)
+ConjugateCopula<Taigen extends string, F extends CopulaForm = "Plain">   // = \`\${Taigen}\${Copula<F>}\`
+Copula<F extends CopulaForm = "Plain">
+CopulaForm = "Plain"(だ)|"Polite"(です)|"Past"(だった)|"PolitePast"(でした)|"Negative"(ではない)|"PoliteNegative"(ではありません)|"NegativePast"(ではなかった)|"PoliteNegativePast"(ではありませんでした)|"CasualNegative"(じゃない)|"CasualPoliteNegative"(じゃありません)|"Written"(である)|"Te"(で)
+
+# Nouns / adverbs — noun-types, adverb-types
+ProperNoun<Name extends string>            // = Name
+InterrogativeAdverb = "なぜ"|"なんで"|"どうして"|"いつ"|"どこ"|"だれ"|"誰"|"何"|"なに"|"どんな"|"どれ"
+Demonstrative = "こう"|"そう"|"ああ"|"どう"
+
+# Phrase combinators — phrase-types
+Particle = "は"|"が"|"を"|"に"|"へ"|"で"|"と"|"から"|"まで"|"よ"|"ね"|"か"|"よね"|"の"|"も"|"なら"|"たら"|"れば"|"でも"|"だけ"|"しか"|"ばかり"|"より"|"ほど"|"や"|"とか"|"って"|"こそ"|"さえ"|"くらい"|"ぐらい"|"ので"|"けど"|"のに"|"し"
+ConditionalParticle = "なら"|"たら"|"れば"|"と"
+PunctuationMark = "、"|"。"|"！"|"？"|"（"|"）"|"("|")"|"「"|"」"|"『"|"』"|"・"
+
+// Preferred output shape for generated annotations:
+Sentence<[
+  ...PhrasePart[]
+]> // joins each part's value with no separator and resolves to the final sentence
+VerbPart<V, F>                 // value = ConjugateVerb<V,F>
+AdjectivePart<A, F>            // value = ConjugateAdjective<A,F>
+NounPart<N extends string>     // one lexical Japanese noun/content unit
+TechnicalTermPart<T extends string> // filenames, code identifiers, ASCII product names, TODO, degraded, etc.
+WhitespacePart<W extends string> // visible spacing between technical terms and Japanese grammar, normally WhitespacePart<" ">
+AdverbPart<A extends string>   // one adverb such as まだ / もう / そう
+ParticlePart<P extends Particle>
+CopulaPart<F extends CopulaForm>
+SuffixPart<S extends string>   // auxiliaries/endings/formal nouns not otherwise modeled, e.g. た, まま, どおり
+PunctuationPart<P extends PunctuationMark>
+
+// Older combinators still exist, but do NOT use NounPhrase for generated long sentences.
+NounPhrase<Noun extends string>                                  // = \`\${Noun}\`
+PhraseWithParticle<Phrase extends string, P extends Particle>    // = \`\${Phrase}\${P}\`
+DemonstrativeAction<Demo extends string, V extends Verb, F extends ConjugationForm = "Dictionary">  // = \`\${Demo}\${ConjugateVerb<V,F>}\`
+ConditionalPhrase<Subject extends string, CP extends ConditionalParticle, Result extends string>    // = \`\${Subject}\${CP}\${Result}\`
+ConnectedPhrases<P1 extends string, P2 extends string>           // = \`\${P1}、\${P2}\`  (inserts the comma 、 for you)
+InterrogativePhrase<Adv extends InterrogativeAdverb, Subject extends string, V extends Verb, VForm extends ConjugationForm, QP extends Particle = "か">  // = \`\${Adv}\${Subject}\${ConjugateVerb<V,VForm>}\${QP}\``;
+
+// Three known-good few-shots (verified against the current English-form API).
+const FEWSHOT = `Example 1 — input "話して":
+{"code":"import type { GodanVerb, Sentence, VerbPart } from \\"typed-japanese\\";\\n\\ntype 話す = GodanVerb & { stem: \\"話\\"; ending: \\"す\\" };\\ntype 話して = Sentence<[VerbPart<話す, \\"Te\\">]>;\\n","en":"\\u201cspeaking\\u201d \\u2014 the て-form of the godan verb 話す","title":"Verb · て-form"}
+
+Example 2 — input "ヒンメルならそうした":
+{"code":"import type { IrregularVerb, NounPart, ParticlePart, Sentence, VerbPart, AdverbPart } from \\"typed-japanese\\";\\n\\ntype する = IrregularVerb & { dictionary: \\"する\\" };\\ntype ヒンメルならそうした = Sentence<[\\n  NounPart<\\"ヒンメル\\">,\\n  ParticlePart<\\"なら\\">,\\n  AdverbPart<\\"そう\\">,\\n  VerbPart<する, \\"Ta\\">\\n]>;\\n","en":"\\u201cIf it were Himmel, he would have done so.\\u201d","title":"Conditional · Himmel"}
+
+Example 3 — input "いいよ、来いよ":
+{"code":"import type { IAdjective, IrregularVerb, AdjectivePart, ParticlePart, PunctuationPart, Sentence, VerbPart } from \\"typed-japanese\\";\\n\\ntype いい = IAdjective & { stem: \\"い\\"; ending: \\"い\\"; irregular: true };\\ntype 来る = IrregularVerb & { dictionary: \\"来る\\" };\\ntype いいよ来いよ = Sentence<[\\n  AdjectivePart<いい, \\"Basic\\">,\\n  ParticlePart<\\"よ\\">,\\n  PunctuationPart<\\"、\\">,\\n  VerbPart<来る, \\"Imperative\\">,\\n  ParticlePart<\\"よ\\">\\n]>;\\n","en":"\\u201cIt's fine \\u2014 come on!\\u201d","title":"Connected · いいよ来いよ"}`;
+
+function buildPrompt(sentence: string, prior?: { code: string; errors: string[] }): string {
+  const base = `You translate a Japanese sentence into "Typed Japanese": a TypeScript snippet built ONLY from the library below, in which a chain of \`type\` aliases composes the sentence and the LAST alias resolves (via the type system) to the EXACT input string.
+
+# The library API (this is the entire available surface — use nothing else)
+${API_REFERENCE}
+
+# Hard rules
+- Import the names you use from "typed-japanese".
+- Conjugation/copula/adjective FORM names are the ENGLISH identifiers defined in the unions above (e.g. "Te", "Ta", "Masu", "Dictionary", "Imperative", "Basic", "Polite", "Past", "Negative", "Plain"). Never use Japanese form names like "て形".
+- The final alias MUST use Sentence<[...parts]> or an alias that expands directly to Sentence<[...parts]>.
+- Build the sentence as a flat, auditable part sequence. Every Japanese particle/助詞 in the input must be its own ParticlePart. Split particle-like compounds when useful: でも can be AdjectivePart<..., "Te"> + ParticlePart<"も">, and という can be ParticlePart<"と"> + VerbPart<いう, "Dictionary">.
+- Every punctuation mark must be a PunctuationPart. Do not hide 、 。 「 」 （ ） inside noun strings.
+- Inflectable Japanese words should use VerbPart, AdjectivePart, or CopulaPart whenever the type system can express them. Use SuruVerb<"起動"> for 起動する / 起動した / 起動され...
+- Technical identifiers and English/code terms (filenames, env, TODO, degraded, pb_test_<slug>) should use TechnicalTermPart. Japanese lexical content words may use NounPart or AdverbPart, but a NounPart/AdverbPart must be ONE lexical unit, not a clause with particles inside it.
+- Do not put leading/trailing spaces inside TechnicalTermPart. Use WhitespacePart<" "> for spaces around English/code terms, while spaces inside one technical expression such as "hello world" or "pb_test_<slug> + sim-users seed" must stay inside that one TechnicalTermPart.
+- Do not use NounPhrase<"...">, template literal glue, or long raw string literals as a shortcut. Literal-looking content is allowed only for technical terms or one lexical content word wrapped in a typed part.
+- The FINAL \`type\` alias must resolve to exactly: ${JSON.stringify(sentence)} — no more, no less. A trailing period/particle counts.
+- If the sentence is richer than the library can express, still keep all particles and punctuation as typed parts; use SuffixPart for small grammatical endings/auxiliaries that are not otherwise modeled.
+- Do not edit files, run commands, or explain your reasoning. Return the JSON object only.
+
+# Output format
+Respond with ONLY a single JSON object (no markdown fence, no prose) with exactly these string fields:
+  {"code": "<the TypeScript snippet, newlines as \\n>", "en": "<short English gloss>", "title": "<short gallery title>"}
+
+# Examples
+${FEWSHOT}`;
+
+  if (!prior) {
+    return `${base}\n\n# Your task\nInput sentence: ${JSON.stringify(sentence)}\nRespond with the JSON object now.`;
+  }
+  return `${base}\n\n# Your previous attempt FAILED verification
+Previous code:
+\`\`\`typescript
+${prior.code}
+\`\`\`
+Verification errors:
+${prior.errors.map((e) => `- ${e}`).join("\n")}
+
+Fix the snippet so it type-checks AND its last alias resolves to exactly ${JSON.stringify(sentence)}. Respond with the corrected JSON object now.`;
+}
+
+// --- model calls -------------------------------------------------------------
+
+function callCodex(prompt: string, model?: string): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "typed-japanese-annotate-"));
+  const outputFile = path.join(tmp, "last-message.txt");
+  const schemaFile = path.join(tmp, "schema.json");
+  fs.writeFileSync(
+    schemaFile,
+    JSON.stringify({
+      type: "object",
+      additionalProperties: false,
+      required: ["code", "en", "title"],
+      properties: {
+        code: { type: "string" },
+        en: { type: "string" },
+        title: { type: "string" },
+      },
+    })
+  );
+
+  const args = [
+    "exec",
+    "--ephemeral",
+    "--sandbox",
+    "read-only",
+    "--color",
+    "never",
+    "-C",
+    REPO,
+    "--output-schema",
+    schemaFile,
+    "-o",
+    outputFile,
+  ];
+  if (model) args.push("--model", model);
+  args.push("-");
+
+  try {
+    const res = spawnSync("codex", args, {
+      input: prompt,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (res.error) {
+      if ((res.error as NodeJS.ErrnoException).code === "ENOENT") {
+        die("`codex` CLI not found on PATH. Install Codex CLI first.");
+      }
+      die(`Failed to run codex: ${res.error.message}`);
+    }
+    if (res.status !== 0) {
+      die(`codex exited with code ${res.status}:\n${res.stderr || res.stdout}`);
+    }
+    if (fs.existsSync(outputFile)) return fs.readFileSync(outputFile, "utf8");
+    return res.stdout;
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function callClaude(prompt: string, model?: string): string {
+  const args = ["-p", prompt, "--output-format", "text"];
+  if (model) args.push("--model", model);
+  const res = spawnSync("claude", args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.error) {
+    if ((res.error as NodeJS.ErrnoException).code === "ENOENT") {
+      die("`claude` CLI not found on PATH. Install Claude Code first.");
+    }
+    die(`Failed to run claude: ${res.error.message}`);
+  }
+  if (res.status !== 0) {
+    die(`claude exited with code ${res.status}:\n${res.stderr || res.stdout}`);
+  }
+  return res.stdout;
+}
+
+function callModel(engine: Args["engine"], prompt: string, model?: string): string {
+  return engine === "codex" ? callCodex(prompt, model) : callClaude(prompt, model);
+}
+
+interface ModelResult {
+  code: string;
+  en: string;
+  title: string;
+}
+
+function parseResult(raw: string): ModelResult {
+  let s = raw.trim();
+  // Strip a stray ```json … ``` fence if the model added one.
+  const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) s = fence[1]!.trim();
+  // Fall back to the outermost { … } span.
+  if (!s.startsWith("{")) {
+    const a = s.indexOf("{");
+    const b = s.lastIndexOf("}");
+    if (a >= 0 && b > a) s = s.slice(a, b + 1);
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(s);
+  } catch (e) {
+    throw new Error(`model did not return valid JSON: ${(e as Error).message}\n--- raw ---\n${raw.slice(0, 800)}`);
+  }
+  const o = obj as Record<string, unknown>;
+  if (typeof o.code !== "string" || !o.code.trim()) {
+    throw new Error(`model JSON missing a "code" string`);
+  }
+  return {
+    code: o.code,
+    en: typeof o.en === "string" ? o.en : "",
+    title: typeof o.title === "string" ? o.title : "",
+  };
+}
+
+// --- verification (type-check + last-alias resolves to the input) ------------
+
+interface CheckResult {
+  ok: boolean;
+  errors: string[];
+  resolved: string | null;
+}
+
+const PART_TYPE_NAMES = new Set([
+  "VerbPart",
+  "AdjectivePart",
+  "NounPart",
+  "TechnicalTermPart",
+  "WhitespacePart",
+  "AdverbPart",
+  "ParticlePart",
+  "CopulaPart",
+  "SuffixPart",
+  "IntensifierPart",
+  "ContractedPart",
+  "NestedPhrasePart",
+  "PunctuationPart",
+]);
+const SCALAR_PART_TYPE_NAMES = new Set([
+  "NounPart",
+  "TechnicalTermPart",
+  "WhitespacePart",
+  "AdverbPart",
+  "ParticlePart",
+  "CopulaPart",
+  "SuffixPart",
+  "IntensifierPart",
+  "ContractedPart",
+  "NestedPhrasePart",
+  "PunctuationPart",
+]);
+const PARTICLE_LITERALS = new Set([
+  "は", "が", "を", "に", "へ", "で", "と", "から", "まで", "よ", "ね", "か", "よね", "の", "も",
+  "なら", "たら", "れば", "でも", "だけ", "しか", "ばかり", "より", "ほど", "や", "とか", "って",
+  "こそ", "さえ", "くらい", "ぐらい", "ので", "けど", "のに", "し",
+]);
+const PUNCTUATION_LITERALS = new Set(["、", "。", "！", "？", "（", "）", "(", ")", "「", "」", "『", "』", "・"]);
+const FORM_LITERALS = new Set([
+  "Dictionary", "Masu", "Te", "Ta", "Nai", "Potential", "Passive", "Causative", "Volitional",
+  "Imperative", "Conditional", "Hypothetical", "Basic", "Polite", "Past", "Negative", "Plain",
+  "PolitePast", "PoliteNegative", "NegativePast", "PoliteNegativePast", "CasualNegative",
+  "CasualPoliteNegative", "Written",
+]);
+const JAPANESE = /[\u3040-\u30ff\u3400-\u9fff]/u;
+const JAPANESE_OR_TECH_BOUNDARY = /[\u3040-\u30ff\u3400-\u9fffA-Za-z0-9_>）」]/u;
+const JAPANESE_PUNCTUATION = /[、。！？「」『』（）]/u;
+const CASE_PARTICLES = new Set(["は", "が", "を", "に", "へ", "で", "と", "の", "も"]);
+
+// Common 形式名詞 / pronouns conventionally written in kana that happen to *contain*
+// a particle homograph (こと→と, もの→の, からだ→から, はず→は). They are single
+// lexemes, so the buried-particle heuristic must not split them. We can't consult
+// the playground's VOCAB table here: dictionary.ts is built with Vite's
+// `import.meta.glob` (unavailable under bun) and, more to the point, these formal
+// nouns aren't course vocabulary anyway. Open-class all-kana content words (やま,
+// はな) are rare in generated output; add them here if they ever surface.
+const KANA_LEXEME_EXCEPTIONS = new Set([
+  "もの", "もん", "こと", "ところ", "とき", "はず", "からだ", "こども", "ひと",
+  "もと", "とも", "つもり",
+]);
+
+function structuralAudit(code: string): string[] {
+  const errors: string[] = [];
+  const sf = ts.createSourceFile("__annotate_structure.ts", code, ts.ScriptTarget.Latest, true);
+  const aliasMap = new Map<string, ts.TypeAliasDeclaration>();
+  for (const stmt of sf.statements) {
+    if (ts.isTypeAliasDeclaration(stmt)) aliasMap.set(stmt.name.text, stmt);
+  }
+
+  const aliases = sf.statements.filter(ts.isTypeAliasDeclaration);
+  const last = aliases[aliases.length - 1];
+  if (!last) return ["structure: snippet declares no final type alias"];
+
+  const entityName = (name: ts.EntityName): string =>
+    ts.isIdentifier(name) ? name.text : name.right.text;
+  const typeRefName = (node: ts.TypeNode): string | null =>
+    ts.isTypeReferenceNode(node) ? entityName(node.typeName) : null;
+
+  function unwrapAlias(node: ts.TypeNode, seen = new Set<string>()): ts.TypeNode {
+    if (!ts.isTypeReferenceNode(node) || node.typeArguments?.length) return node;
+    const name = entityName(node.typeName);
+    if (seen.has(name)) return node;
+    const decl = aliasMap.get(name);
+    if (!decl) return node;
+    seen.add(name);
+    return unwrapAlias(decl.type, seen);
+  }
+
+  function literalArg(node: ts.TypeNode | undefined): string | null {
+    return node &&
+      ts.isLiteralTypeNode(node) &&
+      ts.isStringLiteral(node.literal)
+      ? node.literal.text
+      : null;
+  }
+
+  function isTechnicalTerm(value: string): boolean {
+    return !JAPANESE.test(value) && /[A-Za-z0-9]/.test(value);
+  }
+
+  function hasBuriedParticle(value: string): string | null {
+    const particles = [...PARTICLE_LITERALS].sort((a, b) => b.length - a.length);
+    for (const particle of particles) {
+      if (value === particle) return particle;
+      let idx = value.indexOf(particle);
+      while (idx >= 0) {
+        const before = value[idx - 1] ?? "";
+        const after = value[idx + particle.length] ?? "";
+        const beforeBoundary = before === "" || JAPANESE_OR_TECH_BOUNDARY.test(before);
+        const afterBoundary = after === "" || JAPANESE_OR_TECH_BOUNDARY.test(after);
+        if (particle.length > 1 && beforeBoundary && afterBoundary) return particle;
+        if (CASE_PARTICLES.has(particle) && beforeBoundary && afterBoundary) return particle;
+        idx = value.indexOf(particle, idx + 1);
+      }
+    }
+    return null;
+  }
+
+  function validateLexicalPart(kind: string, value: string): void {
+    if (!value) errors.push(`structure: ${kind} must not be empty`);
+    if (JAPANESE_PUNCTUATION.test(value)) {
+      errors.push(`structure: ${kind}<${JSON.stringify(value)}> hides punctuation; use PunctuationPart`);
+    }
+    if (JAPANESE.test(value) && /[A-Za-z0-9_./:<>\-+]/.test(value)) {
+      errors.push(`structure: ${kind}<${JSON.stringify(value)}> mixes technical text with Japanese; split TechnicalTermPart and Japanese parts`);
+    }
+    if (isTechnicalTerm(value) && kind !== "TechnicalTermPart") {
+      errors.push(`structure: ${kind}<${JSON.stringify(value)}> looks technical; use TechnicalTermPart`);
+    }
+    const buried = KANA_LEXEME_EXCEPTIONS.has(value) ? null : hasBuriedParticle(value);
+    if (buried) {
+      errors.push(`structure: ${kind}<${JSON.stringify(value)}> hides particle ${JSON.stringify(buried)}; split it into ParticlePart`);
+    }
+  }
+
+  function validatePart(name: string, node: ts.TypeReferenceNode): void {
+    const args = node.typeArguments ?? [];
+    if (name === "TechnicalTermPart") {
+      const value = literalArg(args[0]);
+      if (!value) errors.push("structure: TechnicalTermPart needs a string literal argument");
+      else if (value.trim() !== value) {
+        errors.push(`structure: TechnicalTermPart<${JSON.stringify(value)}> has leading/trailing whitespace; use WhitespacePart<" "> around it`);
+      }
+      else if (!isTechnicalTerm(value)) {
+        errors.push(`structure: TechnicalTermPart<${JSON.stringify(value)}> should be reserved for non-Japanese code/technical terms`);
+      }
+      return;
+    }
+    if (name === "WhitespacePart") {
+      const value = literalArg(args[0]);
+      if (!value || !/^\s+$/.test(value)) {
+        errors.push(`structure: WhitespacePart must contain only whitespace, got ${JSON.stringify(value)}`);
+      }
+      return;
+    }
+    if (name === "NounPart" || name === "AdverbPart" || name === "IntensifierPart" || name === "NestedPhrasePart") {
+      const value = literalArg(args[0]);
+      if (value) validateLexicalPart(name, value);
+      return;
+    }
+    if (name === "SuffixPart" || name === "ContractedPart") {
+      const value = literalArg(args[args.length - 1]);
+      const buried = value && !KANA_LEXEME_EXCEPTIONS.has(value) && hasBuriedParticle(value);
+      if (value && (JAPANESE_PUNCTUATION.test(value) || buried)) {
+        errors.push(`structure: ${name}<${JSON.stringify(value)}> is too large; split particles/punctuation into their own parts`);
+      }
+      return;
+    }
+    if (name === "ParticlePart") {
+      const value = literalArg(args[0]);
+      if (!value || !PARTICLE_LITERALS.has(value)) {
+        errors.push(`structure: ParticlePart must use a known particle literal, got ${JSON.stringify(value)}`);
+      }
+      return;
+    }
+    if (name === "PunctuationPart") {
+      const value = literalArg(args[0]);
+      if (!value || !PUNCTUATION_LITERALS.has(value)) {
+        errors.push(`structure: PunctuationPart must use a known punctuation literal, got ${JSON.stringify(value)}`);
+      }
+      return;
+    }
+    if (name === "CopulaPart") {
+      const value = literalArg(args[0]);
+      if (value && !FORM_LITERALS.has(value)) {
+        errors.push(`structure: CopulaPart must use an English copula form, got ${JSON.stringify(value)}`);
+      }
+    }
+  }
+
+  function visit(node: ts.TypeNode): void {
+    const unwrapped = unwrapAlias(node);
+
+    if (ts.isTemplateLiteralTypeNode(unwrapped)) {
+      errors.push("structure: template literal glue hides components; use Sentence<[...parts]> instead");
+      return;
+    }
+    if (ts.isTupleTypeNode(unwrapped)) {
+      for (const element of unwrapped.elements) visit(element);
+      return;
+    }
+    if (!ts.isTypeReferenceNode(unwrapped)) {
+      return;
+    }
+
+    const name = typeRefName(unwrapped);
+    if (name === "NounPhrase") {
+      errors.push("structure: NounPhrase hides sentence structure; use Sentence<[NounPart/ParticlePart/...]> instead");
+      return;
+    }
+    if (name && PART_TYPE_NAMES.has(name)) {
+      validatePart(name, unwrapped);
+      if (!SCALAR_PART_TYPE_NAMES.has(name)) {
+        for (const arg of unwrapped.typeArguments ?? []) visit(arg);
+      }
+      return;
+    }
+    for (const arg of unwrapped.typeArguments ?? []) visit(arg);
+  }
+
+  const root = unwrapAlias(last.type);
+  const rootName = typeRefName(root);
+  if (rootName !== "Sentence") {
+    errors.push("structure: final alias must be Sentence<[...parts]> so particles and literals are auditable");
+  }
+  visit(root);
+
+  return [...new Set(errors)];
+}
+
+function verify(code: string, sentence: string): CheckResult {
+  const fileName = path.join(PLAYGROUND, "__annotate_check.ts");
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    lib: ["lib.es2020.d.ts"],
+    baseUrl: REPO,
+    paths: { "typed-japanese": ["src/index"] },
+  };
+
+  const host = ts.createCompilerHost(options);
+  const origGet = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, lang, ...rest) =>
+    name === fileName
+      ? ts.createSourceFile(name, code, lang)
+      : origGet(name, lang, ...rest);
+  const origRead = host.readFile.bind(host);
+  host.readFile = (name) => (name === fileName ? code : origRead(name));
+  const origExists = host.fileExists.bind(host);
+  host.fileExists = (name) => name === fileName || origExists(name);
+
+  const program = ts.createProgram([fileName], options, host);
+  const diags = ts.getPreEmitDiagnostics(program).filter((d) => !IGNORE.has(d.code));
+  const errors = diags.map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, " ")}`);
+
+  // Resolve the last type alias to its string-literal value.
+  let resolved: string | null = null;
+  const sf = program.getSourceFile(fileName);
+  if (sf) {
+    const aliases = sf.statements.filter(ts.isTypeAliasDeclaration);
+    const last = aliases[aliases.length - 1];
+    if (!last) {
+      errors.push("snippet declares no `type` alias to use as the sentence");
+    } else {
+      try {
+        const checker = program.getTypeChecker();
+        const type = checker.getTypeFromTypeNode(last.type);
+        const str = checker.typeToString(type, undefined, ts.TypeFormatFlags.NoTruncation);
+        const m = str.match(/^"([\s\S]*)"$/);
+        resolved = m ? m[1] : str;
+      } catch (e) {
+        errors.push(`could not resolve the last alias: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  if (errors.length === 0 && resolved !== sentence) {
+    errors.push(
+      `last alias resolves to ${JSON.stringify(resolved)} but must resolve to ${JSON.stringify(sentence)}`
+    );
+  }
+  errors.push(...structuralAudit(code));
+  return { ok: errors.length === 0, errors, resolved };
+}
+
+// --- gallery store -----------------------------------------------------------
+
+interface Snippet {
+  id: string;
+  title: string;
+  jp: string;
+  en: string;
+  code: string;
+}
+
+function loadStore(): Snippet[] {
+  if (!fs.existsSync(GEN_JSON)) return [];
+  try {
+    const data = JSON.parse(fs.readFileSync(GEN_JSON, "utf8"));
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveStore(entries: Snippet[]): void {
+  fs.writeFileSync(GEN_JSON, JSON.stringify(entries, null, 2) + "\n");
+}
+
+function makeId(sentence: string, existing: Snippet[]): string {
+  let n = 0;
+  for (const s of sentence) n = (n * 31 + s.codePointAt(0)!) >>> 0;
+  let id = `gen-${n.toString(36)}`;
+  const taken = new Set(existing.map((e) => e.id));
+  let id2 = id, k = 1;
+  while (taken.has(id2)) id2 = `${id}-${k++}`;
+  return id2;
+}
+
+// --- main --------------------------------------------------------------------
+
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+  if (!args.sentence) {
+    console.log(USAGE);
+    die("a Japanese sentence is required.");
+  }
+
+  console.log(`\n${cyan("◆ annotate")} ${args.sentence}`);
+
+  let best: { result: ModelResult; check: CheckResult } | null = null;
+  let prior: { code: string; errors: string[] } | undefined;
+
+  for (let attempt = 1; attempt <= args.retries; attempt++) {
+    console.log(dim(`  attempt ${attempt}/${args.retries} — asking ${args.engine}…`));
+    const prompt = buildPrompt(args.sentence, prior);
+
+    let result: ModelResult;
+    try {
+      result = parseResult(callModel(args.engine, prompt, args.model));
+    } catch (e) {
+      console.log(dim(`    ${(e as Error).message.split("\n")[0]}`));
+      prior = { code: prior?.code ?? "", errors: [(e as Error).message] };
+      continue;
+    }
+
+    const check = verify(result.code, args.sentence);
+    best = { result, check };
+
+    if (check.ok) {
+      console.log(green(`  ✓ verified — resolves to "${check.resolved}"`));
+      break;
+    }
+    console.log(`  ✗ ${check.errors.length} error(s):`);
+    for (const e of check.errors.slice(0, 4)) console.log(dim(`      ${e}`));
+    prior = { code: result.code, errors: check.errors };
+  }
+
+  if (!best || !best.check.ok) {
+    console.log(`\n${"\x1b[31m"}✗ Gave up after ${args.retries} attempt(s).\x1b[0m`);
+    if (best) {
+      console.log(dim("\nBest attempt (not installed):\n"));
+      console.log(best.result.code);
+    }
+    process.exit(1);
+  }
+
+  if (args.dryRun) {
+    console.log(dim("\n--dry-run: not writing to the gallery. Snippet:\n"));
+    console.log(best.result.code);
+    process.exit(0);
+  }
+
+  const store = loadStore();
+  const existingIdx = store.findIndex((e) => e.jp === args.sentence);
+  const id = args.id ?? (existingIdx >= 0 ? store[existingIdx]!.id : makeId(args.sentence, store));
+  const entry: Snippet = {
+    id,
+    title: args.title || best.result.title || args.sentence,
+    jp: args.sentence,
+    en: args.en || best.result.en || "",
+    code: best.result.code,
+  };
+  if (existingIdx >= 0) store[existingIdx] = entry;
+  else store.push(entry);
+  saveStore(store);
+
+  console.log(green(`\n✓ Installed as "${entry.title}" (${id}).`));
+  console.log(dim(`  ${existingIdx >= 0 ? "Updated" : "Added"} → ${path.relative(REPO, GEN_JSON)}`));
+  console.log(dim(`  Run \`pnpm dev\` (in playground/) and open the Type Playground to see it.`));
+}
+
+// Run as a CLI when invoked directly; stay importable (structuralAudit/verify)
+// for tests when loaded as a module.
+if (import.meta.main) main();
+
+export { structuralAudit, verify };

--- a/playground/scripts/verify-snippets.mjs
+++ b/playground/scripts/verify-snippets.mjs
@@ -1,6 +1,6 @@
 /**
- * Verify that every tutorial example's `code` snippet type-checks against the
- * real Typed Japanese library. Run from the playground/ directory:
+ * Verify that every tutorial/generated example's `code` snippet type-checks
+ * against the real Typed Japanese library. Run from the playground/ directory:
  *
  *   node scripts/verify-snippets.mjs            # human summary
  *   node scripts/verify-snippets.mjs --json     # machine-readable failures
@@ -19,6 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLAYGROUND = path.resolve(__dirname, "..");
 const REPO = path.resolve(PLAYGROUND, "..");
 const CHAPTERS_DIR = path.join(PLAYGROUND, "src/tutorial/chapters");
+const GENERATED_JSON = path.join(PLAYGROUND, "src/data/examples.generated.json");
 const IGNORE = new Set([6133, 6196, 6192, 6198, 6205]);
 
 const jsonOut = process.argv.includes("--json");
@@ -59,6 +60,20 @@ for (const f of chapterFiles) {
       });
     })
   );
+}
+
+if (fs.existsSync(GENERATED_JSON)) {
+  const generated = JSON.parse(fs.readFileSync(GENERATED_JSON, "utf8"));
+  if (Array.isArray(generated)) {
+    generated.forEach((ex, i) => {
+      examples.push({
+        id: "generated",
+        file: `generated/${ex.id ?? i}`,
+        jp: ex.jp ?? "",
+        code: ex.code ?? "",
+      });
+    });
+  }
 }
 
 // --- build one in-memory program over all snippets ---
@@ -146,7 +161,7 @@ for (const ex of examples) {
 if (jsonOut) {
   console.log(JSON.stringify({ total: examples.length, failed: report.length, report }, null, 2));
 } else {
-  console.log(`Checked ${examples.length} example snippets across ${chapterFiles.length} chapters.`);
+  console.log(`Checked ${examples.length} example snippets across ${chapterFiles.length} chapters plus generated snippets.`);
   if (report.length === 0) {
     console.log("✓ All snippets type-check against the library.");
   } else {

--- a/playground/src/analysis/parse.ts
+++ b/playground/src/analysis/parse.ts
@@ -23,8 +23,13 @@ export type GrammarCategory =
   | "verb"
   | "adjective"
   | "noun"
+  | "technical"
+  | "whitespace"
   | "adverb"
   | "particle"
+  | "copula"
+  | "suffix"
+  | "punctuation"
   | "form"
   | "demonstrative"
   | "interrogative"
@@ -63,6 +68,8 @@ export interface Analysis {
 // --- grammar vocabulary (mirrors the library's .d.ts unions) -----------------
 
 const COMPOSITIONAL = new Set([
+  "Sentence",
+  "PhraseSequence",
   "ConditionalPhrase",
   "ConnectedPhrases",
   "InterrogativePhrase",
@@ -88,19 +95,35 @@ const CATEGORY_BY_NAME: Record<string, GrammarCategory> = {
   ConjugateVerb: "conjugation",
   ConjugateAdjective: "conjugation",
   ConjugateCopula: "conjugation",
+  Sentence: "phrase",
+  PhraseSequence: "phrase",
   GodanVerb: "verb",
   IchidanVerb: "verb",
   IrregularVerb: "verb",
+  SuruVerb: "verb",
   Verb: "verb",
   IAdjective: "adjective",
   NaAdjective: "adjective",
   Adjective: "adjective",
   ProperNoun: "noun",
+  VerbPart: "verb",
+  AdjectivePart: "adjective",
+  NounPart: "noun",
+  TechnicalTermPart: "technical",
+  WhitespacePart: "whitespace",
+  AdverbPart: "adverb",
+  ParticlePart: "particle",
+  CopulaPart: "copula",
+  SuffixPart: "suffix",
+  IntensifierPart: "adverb",
+  ContractedPart: "suffix",
+  NestedPhrasePart: "phrase",
+  PunctuationPart: "punctuation",
 };
 
 const FORMS = new Set([
   "Dictionary", "Masu", "Te", "Ta", "Nai", "Potential", "Passive", "Causative",
-  "Volitional", "Imperative", "Conditional", "Hypothetical", "Basic", "Polite", "Past", "Negative",
+  "Volitional", "Imperative", "Conditional", "Hypothetical", "Basic", "Polite", "Past", "Negative", "Ta",
   // copula forms
   "Plain", "PolitePast", "PoliteNegative", "NegativePast", "PoliteNegativePast",
   "CasualNegative", "CasualPoliteNegative", "Written",
@@ -112,7 +135,10 @@ const INTERROGATIVE = new Set([
 ]);
 const PARTICLES = new Set([
   "は", "が", "を", "に", "へ", "で", "と", "から", "まで", "よ", "ね", "か", "よね", "の", "も",
+  "なら", "たら", "れば", "でも", "だけ", "しか", "ばかり", "より", "ほど", "や", "とか", "って", "こそ", "さえ", "くらい",
+  "ぐらい", "ので", "けど", "のに", "し",
 ]);
+const PUNCTUATION = new Set(["、", "。", "！", "？", "（", "）", "(", ")", "「", "」", "『", "』", "・"]);
 
 function classifyLiteral(value: string): GrammarCategory {
   if (FORMS.has(value)) return "form";
@@ -120,6 +146,7 @@ function classifyLiteral(value: string): GrammarCategory {
   if (INTERROGATIVE.has(value)) return "interrogative";
   if (CONDITIONAL.has(value)) return "particle";
   if (PARTICLES.has(value)) return "particle";
+  if (PUNCTUATION.has(value)) return "punctuation";
   return "literal";
 }
 
@@ -281,6 +308,81 @@ export async function buildTree(
     return null;
   }
 
+  const PART_TYPES = new Set([
+    "VerbPart",
+    "AdjectivePart",
+    "NounPart",
+    "TechnicalTermPart",
+    "WhitespacePart",
+    "AdverbPart",
+    "ParticlePart",
+    "CopulaPart",
+    "SuffixPart",
+    "IntensifierPart",
+    "ContractedPart",
+    "NestedPhrasePart",
+    "PunctuationPart",
+  ]);
+
+  const SCALAR_PART_TYPES = new Set([
+    "NounPart",
+    "TechnicalTermPart",
+    "WhitespacePart",
+    "AdverbPart",
+    "ParticlePart",
+    "CopulaPart",
+    "SuffixPart",
+    "IntensifierPart",
+    "ContractedPart",
+    "NestedPhrasePart",
+    "PunctuationPart",
+  ]);
+
+  function stringLiteralArg(node: TS.TypeNode | undefined): string | null {
+    return node &&
+      ts.isLiteralTypeNode(node) &&
+      ts.isStringLiteral(node.literal)
+      ? node.literal.text
+      : null;
+  }
+
+  function buildPartNode(
+    name: string,
+    node: TS.TypeReferenceNode,
+    idPath: string,
+    start: number,
+    end: number,
+    sourceText: string,
+    alias?: string
+  ): CompositionNode {
+    const args = node.typeArguments ?? [];
+    const firstLiteral = stringLiteralArg(args[0]);
+    const lastLiteral = stringLiteralArg(args[args.length - 1]);
+    const label =
+      alias ??
+      (name === "CopulaPart"
+        ? "Copula"
+        : name === "WhitespacePart"
+        ? "space"
+        : name === "ContractedPart" && lastLiteral
+        ? lastLiteral
+        : firstLiteral ?? name);
+    const children = SCALAR_PART_TYPES.has(name)
+      ? []
+      : args.map((arg, i) => build(arg, `${idPath}.${i}`));
+
+    return {
+      id: idPath,
+      label,
+      ctor: name,
+      category: CATEGORY_BY_NAME[name] ?? "other",
+      text: `${sourceText}["value"]`,
+      start,
+      end,
+      children,
+    };
+  }
+
   function build(node: TS.TypeNode, idPath: string): CompositionNode {
     // Unwrap parentheses so `(A & B)` etc. don't add a useless level.
     if (ts.isParenthesizedTypeNode(node)) return build(node.type, idPath);
@@ -304,6 +406,20 @@ export async function buildTree(
         start,
         end,
         children: [],
+      };
+    }
+
+    // Tuple type inside Sentence<[...parts]>: show each part as a child.
+    if (ts.isTupleTypeNode(node)) {
+      return {
+        id: idPath,
+        label: "Parts",
+        ctor: "[]",
+        category: "phrase",
+        text,
+        start,
+        end,
+        children: node.elements.map((el, i) => build(el, `${idPath}.${i}`)),
       };
     }
 
@@ -339,15 +455,19 @@ export async function buildTree(
       (name && CATEGORY_BY_NAME[name]) || "other";
 
     let children: CompositionNode[] = [];
-    if (
-      name &&
-      COMPOSITIONAL.has(name) &&
-      ts.isTypeReferenceNode(eff.node) &&
-      eff.node.typeArguments
-    ) {
-      children = eff.node.typeArguments.map((arg, i) =>
-        build(arg, `${idPath}.${i}`)
-      );
+
+    if (name && PART_TYPES.has(name) && ts.isTypeReferenceNode(eff.node)) {
+      return buildPartNode(name, eff.node, idPath, start, end, text, eff.alias);
+    }
+
+    if (name && COMPOSITIONAL.has(name) && ts.isTypeReferenceNode(eff.node)) {
+      const args = eff.node.typeArguments ?? [];
+      const tupleArg = args[0] && ts.isTupleTypeNode(args[0]) ? args[0] : null;
+      if ((name === "Sentence" || name === "PhraseSequence") && tupleArg) {
+        children = tupleArg.elements.map((arg, i) => build(arg, `${idPath}.${i}`));
+      } else {
+        children = args.map((arg, i) => build(arg, `${idPath}.${i}`));
+      }
     }
 
     const label = eff.alias ?? name ?? text;

--- a/playground/src/components/Analyzer.tsx
+++ b/playground/src/components/Analyzer.tsx
@@ -68,6 +68,7 @@ export default function Analyzer({ code, gloss }: Props) {
   const [tree, setTree] = useState<CompositionNode | null>(null);
   const [diagnostics, setDiagnostics] = useState<Diag[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [showWhitespace, setShowWhitespace] = useState(false);
   const [ready, setReady] = useState(false);
 
   const editorRef = useRef<StandaloneEditor | null>(null);
@@ -225,26 +226,44 @@ export default function Analyzer({ code, gloss }: Props) {
     [tree, selectedNodeId]
   );
 
+  useEffect(() => {
+    if (!showWhitespace && selectedNode?.category === "whitespace") {
+      setSelectedNodeId(null);
+      decorationsRef.current?.clear();
+    }
+  }, [selectedNode, showWhitespace]);
+
   return (
     <div className="flex flex-col gap-4">
       {/* Sentence structure — visualization on top */}
       <section className="tj-card flex flex-col overflow-hidden p-0">
         <div className="flex items-center justify-between gap-2.5 px-4 py-3 border-b border-border">
           <h2 className="tj-panel-title">Sentence structure</h2>
-          {aliases.length > 1 && (
-            <select
-              className="tj-select w-auto max-w-[230px] px-2.5 py-[5px] font-jp text-[0.86rem]"
-              value={selectedAlias ?? ""}
-              onChange={(e) => pickAlias(e.target.value)}
-              aria-label="Type to visualise"
-            >
-              {aliases.map((a) => (
-                <option key={a.name} value={a.name}>
-                  {a.name}
-                </option>
-              ))}
-            </select>
-          )}
+          <div className="flex items-center gap-2.5 flex-wrap justify-end">
+            <label className="flex items-center gap-1.5 text-[0.78rem] font-bold text-ink-600 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                className="accent-sakura-500"
+                checked={showWhitespace}
+                onChange={(e) => setShowWhitespace(e.target.checked)}
+              />
+              <span>空白</span>
+            </label>
+            {aliases.length > 1 && (
+              <select
+                className="tj-select w-auto max-w-[230px] px-2.5 py-[5px] font-jp text-[0.86rem]"
+                value={selectedAlias ?? ""}
+                onChange={(e) => pickAlias(e.target.value)}
+                aria-label="Type to visualise"
+              >
+                {aliases.map((a) => (
+                  <option key={a.name} value={a.name}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-col gap-0.5 pt-3.5 px-4 pb-2">
@@ -260,6 +279,7 @@ export default function Analyzer({ code, gloss }: Props) {
               node={tree}
               selectedId={selectedNodeId}
               onSelect={handleSelectNode}
+              showWhitespace={showWhitespace}
             />
           ) : (
             <p className="tj-subtle">

--- a/playground/src/components/CompositionTree.tsx
+++ b/playground/src/components/CompositionTree.tsx
@@ -11,8 +11,13 @@ export const CATEGORY_META: Record<
   verb: { jp: "動詞", en: "Verb", varName: "--cat-verb" },
   adjective: { jp: "形容詞", en: "Adjective", varName: "--cat-adjective" },
   noun: { jp: "名詞", en: "Noun", varName: "--cat-noun" },
+  technical: { jp: "技術語", en: "Technical", varName: "--cat-noun" },
+  whitespace: { jp: "空白", en: "Whitespace", varName: "--cat-literal" },
   adverb: { jp: "副詞", en: "Adverb", varName: "--cat-adverb" },
   particle: { jp: "助詞", en: "Particle", varName: "--cat-particle" },
+  copula: { jp: "コピュラ", en: "Copula", varName: "--cat-conjugation" },
+  suffix: { jp: "接尾", en: "Suffix", varName: "--cat-form" },
+  punctuation: { jp: "記号", en: "Punctuation", varName: "--cat-literal" },
   form: { jp: "活用形", en: "Form", varName: "--cat-form" },
   demonstrative: { jp: "指示詞", en: "Demonstrative", varName: "--cat-demonstrative" },
   interrogative: { jp: "疑問詞", en: "Interrogative", varName: "--cat-interrogative" },
@@ -24,6 +29,7 @@ interface Props {
   node: CompositionNode;
   selectedId: string | null;
   onSelect: (node: CompositionNode) => void;
+  showWhitespace?: boolean;
   depth?: number;
 }
 
@@ -31,9 +37,12 @@ export default function CompositionTree({
   node,
   selectedId,
   onSelect,
+  showWhitespace = false,
   depth = 0,
 }: Props) {
   const { lang } = useLang();
+  if (!showWhitespace && node.category === "whitespace") return null;
+
   const meta = CATEGORY_META[node.category];
   const color = `var(${meta.varName})`;
   const isLiteral = node.ctor === null && node.children.length === 0;
@@ -82,15 +91,18 @@ export default function CompositionTree({
 
       {node.children.length > 0 && (
         <div className="ml-4 pl-3 border-l-2 border-dashed border-border-strong">
-          {node.children.map((child) => (
-            <CompositionTree
-              key={child.id}
-              node={child}
-              selectedId={selectedId}
-              onSelect={onSelect}
-              depth={depth + 1}
-            />
-          ))}
+          {node.children
+            .filter((child) => showWhitespace || child.category !== "whitespace")
+            .map((child) => (
+              <CompositionTree
+                key={child.id}
+                node={child}
+                selectedId={selectedId}
+                onSelect={onSelect}
+                showWhitespace={showWhitespace}
+                depth={depth + 1}
+              />
+            ))}
         </div>
       )}
     </div>

--- a/playground/src/components/Playground.tsx
+++ b/playground/src/components/Playground.tsx
@@ -1,28 +1,47 @@
 import { useState } from "react";
 import { SNIPPETS } from "../data/examples";
+import { GENERATED_SNIPPETS } from "../data/examples.generated";
 import Analyzer from "./Analyzer";
+
+// Hand-curated examples first, then any AI-generated ones (appended by
+// `bun run annotate`). Both index into the same flat list the Analyzer reads.
+const ALL = [...SNIPPETS, ...GENERATED_SNIPPETS];
+const CURATED_COUNT = SNIPPETS.length;
 
 export default function Playground() {
   const [index, setIndex] = useState(0);
-  const active = SNIPPETS[index] ?? SNIPPETS[0]!;
+  const active = ALL[index] ?? ALL[0]!;
+
+  const chip = (start: number, end: number) =>
+    ALL.slice(start, end).map((s, i) => {
+      const real = start + i;
+      return (
+        <button
+          key={s.id}
+          type="button"
+          className={`tj-chip cursor-pointer border border-border ${real === index ? "bg-sakura-500 text-on-accent border-sakura-500" : ""}`}
+          onClick={() => setIndex(real)}
+        >
+          {s.title}
+        </button>
+      );
+    });
 
   return (
     <div className="flex flex-col gap-3.5">
       <div className="flex items-center gap-3 flex-wrap">
         <span className="tj-label">Examples</span>
-        <div className="flex gap-[7px] flex-wrap">
-          {SNIPPETS.map((s, i) => (
-            <button
-              key={s.id}
-              type="button"
-              className={`tj-chip cursor-pointer border border-border ${i === index ? "bg-sakura-500 text-on-accent border-sakura-500" : ""}`}
-              onClick={() => setIndex(i)}
-            >
-              {s.title}
-            </button>
-          ))}
-        </div>
+        <div className="flex gap-[7px] flex-wrap">{chip(0, CURATED_COUNT)}</div>
       </div>
+
+      {GENERATED_SNIPPETS.length > 0 && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="tj-label">✨ Generated</span>
+          <div className="flex gap-[7px] flex-wrap">
+            {chip(CURATED_COUNT, ALL.length)}
+          </div>
+        </div>
+      )}
 
       <Analyzer code={active.code} gloss={active.en} />
 

--- a/playground/src/data/examples.generated.json
+++ b/playground/src/data/examples.generated.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "gen-mmlgl",
+    "title": "Verb · past",
+    "jp": "食べた",
+    "en": "\"ate\" — the past form of the ichidan verb 食べる",
+    "code": "import type { IchidanVerb, Sentence, VerbPart } from \"typed-japanese\";\n\ntype 食べる = IchidanVerb & { stem: \"食べ\"; ending: \"る\" };\ntype 食べた = Sentence<[VerbPart<食べる, \"Ta\">]>;\n"
+  },
+  {
+    "id": "gen-1ys44t3",
+    "title": "Platform · migrate TODO",
+    "jp": "platform-migrate-job.yaml の pb_test_<slug> + sim-users seed はまだ TODO（platform 側に seed:test-env スクリプトが要る）。それまで env は隔離されたまま起動するが、connector / agent-IM mint は degraded になりうる。これは「不完全でも隔離優先」という今回の方針どおり。",
+    "en": "The platform migration job seed setup is still TODO; until then env stays isolated, possible degraded minting is accepted under the current isolation-first policy.",
+    "code": "import type { GodanVerb, NaAdjective, SuruVerb, Sentence, TechnicalTermPart, WhitespacePart, NounPart, AdverbPart, ParticlePart, PunctuationPart, VerbPart, AdjectivePart, SuffixPart } from \"typed-japanese\";\n\ntype 要る = GodanVerb & { type: \"godan\"; stem: \"要\"; ending: \"る\" };\ntype いう = GodanVerb & { type: \"godan\"; stem: \"い\"; ending: \"う\" };\ntype 不完全 = NaAdjective & { type: \"na-adjective\"; stem: \"不完全\" };\n\ntype TypedJapanese = Sentence<[\n  TechnicalTermPart<\"platform-migrate-job.yaml\">,\n  WhitespacePart<\" \">,\n  ParticlePart<\"の\">,\n  WhitespacePart<\" \">,\n  TechnicalTermPart<\"pb_test_<slug> + sim-users seed\">,\n  WhitespacePart<\" \">,\n  ParticlePart<\"は\">,\n  AdverbPart<\"まだ\">,\n  WhitespacePart<\" \">,\n  TechnicalTermPart<\"TODO\">,\n  PunctuationPart<\"（\">,\n  TechnicalTermPart<\"platform\">,\n  WhitespacePart<\" \">,\n  NounPart<\"側\">,\n  ParticlePart<\"に\">,\n  WhitespacePart<\" \">,\n  TechnicalTermPart<\"seed:test-env\">,\n  WhitespacePart<\" \">,\n  NounPart<\"スクリプト\">,\n  ParticlePart<\"が\">,\n  VerbPart<要る, \"Dictionary\">,\n  PunctuationPart<\"）\">,\n  PunctuationPart<\"。\">,\n  NounPart<\"それ\">,\n  ParticlePart<\"まで\">,\n  WhitespacePart<\" \">,\n  TechnicalTermPart<\"env\">,\n  WhitespacePart<\" \">,\n  ParticlePart<\"は\">,\n  NounPart<\"隔離\">,\n  SuffixPart<\"された\">,\n  SuffixPart<\"まま\">,\n  VerbPart<SuruVerb<\"起動\">, \"Dictionary\">,\n  ParticlePart<\"が\">,\n  PunctuationPart<\"、\">,\n  TechnicalTermPart<\"connector / agent-IM mint\">,\n  WhitespacePart<\" \">,\n  ParticlePart<\"は\">,\n  WhitespacePart<\" \">,\n  TechnicalTermPart<\"degraded\">,\n  WhitespacePart<\" \">,\n  ParticlePart<\"に\">,\n  SuffixPart<\"なりうる\">,\n  PunctuationPart<\"。\">,\n  NounPart<\"これ\">,\n  ParticlePart<\"は\">,\n  PunctuationPart<\"「\">,\n  AdjectivePart<不完全, \"Te\">,\n  ParticlePart<\"も\">,\n  NounPart<\"隔離優先\">,\n  PunctuationPart<\"」\">,\n  ParticlePart<\"と\">,\n  VerbPart<いう, \"Dictionary\">,\n  NounPart<\"今回\">,\n  ParticlePart<\"の\">,\n  NounPart<\"方針\">,\n  SuffixPart<\"どおり\">,\n  PunctuationPart<\"。\">\n]>;\n"
+  }
+]

--- a/playground/src/data/examples.generated.ts
+++ b/playground/src/data/examples.generated.ts
@@ -1,0 +1,15 @@
+/**
+ * AI-generated playground snippets, kept separate from the hand-curated SNIPPETS
+ * in ./examples.ts. Entries are appended by the annotate workflow:
+ *
+ *   cd playground && bun run annotate "<日本語の文>"
+ *
+ * Each entry has been verified to type-check against the library AND to have its
+ * last `type` alias resolve to exactly its `jp` sentence. The data lives in the
+ * sibling examples.generated.json (the script's store); this module just types
+ * and re-exports it. Don't edit the JSON by hand — re-run annotate instead.
+ */
+import type { Snippet } from "./examples";
+import data from "./examples.generated.json";
+
+export const GENERATED_SNIPPETS = data as ReadonlyArray<Snippet>;

--- a/playground/src/data/examples.ts
+++ b/playground/src/data/examples.ts
@@ -24,7 +24,7 @@ export const SNIPPETS: ReadonlyArray<Snippet> = [
 type 話す = GodanVerb & { stem: "話"; ending: "す" };
 
 // Conjugate it. Hover 話して in the editor — TypeScript computes "話して".
-type 話して = ConjugateVerb<話す, "て形">;
+type 話して = ConjugateVerb<話す, "Te">;
 `,
   },
   {
@@ -43,7 +43,7 @@ type ヒンメル = ProperNoun<"ヒンメル">;
 type する = IrregularVerb & { dictionary: "する" };
 
 // そうした = "did so" (past form of そうする)
-type そうした = DemonstrativeAction<"そう", する, "た形">;
+type そうした = DemonstrativeAction<"そう", する, "Ta">;
 
 type ヒンメルならそうした = ConditionalPhrase<ヒンメル, "なら", そうした>;
 `,
@@ -65,8 +65,8 @@ type ヒンメルならそうした = ConditionalPhrase<ヒンメル, "なら", 
 type いい = IAdjective & { stem: "い"; ending: "い"; irregular: true };
 type 来る = IrregularVerb & { dictionary: "来る" };
 
-type いいよ = PhraseWithParticle<ConjugateAdjective<いい, "基本形">, "よ">;
-type 来いよ = PhraseWithParticle<ConjugateVerb<来る, "命令形">, "よ">;
+type いいよ = PhraseWithParticle<ConjugateAdjective<いい, "Basic">, "よ">;
+type 来いよ = PhraseWithParticle<ConjugateVerb<来る, "Imperative">, "よ">;
 
 type いいよ来いよ = ConnectedPhrases<いいよ, 来いよ>;
 `,
@@ -85,7 +85,7 @@ type どうしてパンを食べるの = InterrogativePhrase<
   "どうして",
   "パンを",
   食べる,
-  "辞書形",
+  "Dictionary",
   "の"
 >;
 `,
@@ -103,7 +103,7 @@ type どうしてパンを食べるの = InterrogativePhrase<
 
 type 綺麗 = NaAdjective & { stem: "綺麗" };
 
-type 綺麗ですね = PhraseWithParticle<ConjugateAdjective<綺麗, "丁寧形">, "ね">;
+type 綺麗ですね = PhraseWithParticle<ConjugateAdjective<綺麗, "Polite">, "ね">;
 `,
   },
 ];

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -8,6 +8,7 @@
 
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/src/adjective-types.d.ts
+++ b/src/adjective-types.d.ts
@@ -20,7 +20,8 @@ export type AdjectiveConjugationForm =
   | "Basic" // Basic form
   | "Polite" // Polite form
   | "Past" // Past form
-  | "Negative"; // Negative form
+  | "Negative" // Negative form
+  | "Te"; // Connective form
 
 // I-adjective conjugation mapping
 type IAdjectiveConjugationMap = {
@@ -29,6 +30,7 @@ type IAdjectiveConjugationMap = {
     Polite: "いです";
     Past: "かった";
     Negative: "くない";
+    Te: "くて";
   };
 };
 

--- a/src/phrase-types.d.ts
+++ b/src/phrase-types.d.ts
@@ -11,6 +11,7 @@ import type {
   GodanVerb,
   IchidanVerb,
   IrregularVerb,
+  SuruVerb,
   Verb,
 } from "./verb-types";
 import type { Copula, CopulaForm } from "./copula-types";
@@ -33,7 +34,27 @@ export type Particle =
   | "か" // Question particle
   | "よね" // Combined emphasis and agreement
   | "の" // Nominalizer/question particle
-  | "も"; // Also/even particle
+  | "も" // Also/even particle
+  | "なら" // Conditional/topic particle
+  | "たら" // Conditional particle
+  | "れば" // Conditional particle
+  | "でも" // Even if / even with
+  | "だけ" // Only
+  | "しか" // Only (with negative predicate)
+  | "ばかり" // Only / just
+  | "より" // Than / from
+  | "ほど" // Extent / about
+  | "や" // And / such as
+  | "とか" // Such as / quote-like
+  | "って" // Casual topic/quote marker
+  | "こそ" // Emphatic focus
+  | "さえ" // Even
+  | "くらい" // About / extent
+  | "ぐらい" // About / extent
+  | "ので" // Because
+  | "けど" // But / although
+  | "のに" // Although
+  | "し"; // Listing reasons
 // Note: the copula だ is NOT a particle. It inflects, so it lives in
 // ./copula-types as `ConjugateCopula` / `Copula`.
 
@@ -43,10 +64,15 @@ export type PunctuationMark =
   | "。" // Japanese period (句点/くてん)
   | "！" // Exclamation mark
   | "？" // Question mark
+  | "（" // Opening full-width parenthesis
+  | "）" // Closing full-width parenthesis
+  | "(" // Opening ASCII parenthesis
+  | ")" // Closing ASCII parenthesis
   | "「" // Opening quotation mark
   | "」" // Closing quotation mark
   | "『" // Opening double quotation mark
-  | "』"; // Closing double quotation mark
+  | "』" // Closing double quotation mark
+  | "・"; // Interpunct
 
 // Conditional particles
 export type ConditionalParticle = "なら" | "たら" | "れば" | "と";
@@ -104,9 +130,12 @@ export type PhrasePart =
   | VerbPart
   | AdjectivePart
   | NounPart
+  | TechnicalTermPart
+  | WhitespacePart
   | AdverbPart
   | ParticlePart
   | CopulaPart
+  | SuffixPart
   | IntensifierPart
   | ContractedPart
   | NestedPhrasePart
@@ -139,6 +168,18 @@ export type NounPart<N extends string = string> = {
   value: N;
 };
 
+export type TechnicalTermPart<T extends string = string> = {
+  type: "technical";
+  term: T;
+  value: T;
+};
+
+export type WhitespacePart<W extends string = " "> = {
+  type: "whitespace";
+  whitespace: W;
+  value: W;
+};
+
 export type AdverbPart<A extends string = string> = {
   type: "adverb";
   adverb: A;
@@ -155,6 +196,12 @@ export type CopulaPart<F extends CopulaForm = CopulaForm> = {
   type: "copula";
   form: F;
   value: Copula<F>;
+};
+
+export type SuffixPart<S extends string = string> = {
+  type: "suffix";
+  suffix: S;
+  value: S;
 };
 
 export type IntensifierPart<I extends string = string> = {
@@ -183,10 +230,15 @@ export type PunctuationPart<P extends PunctuationMark = PunctuationMark> = {
   value: P;
 };
 
-type PhraseSequence<Parts extends PhrasePart[] = PhrasePart[]> = {
+export type PhraseSequence<Parts extends readonly PhrasePart[] = readonly PhrasePart[]> = {
   parts: Parts;
   value: JoinPhrasePartsValue<Parts>;
 };
+
+export type Sentence<Parts extends readonly PhrasePart[]> =
+  JoinPhrasePartsValue<Parts>;
+
+export type PartValue<Part extends PhrasePart> = Part["value"];
 
 export type NestedPhrase<T extends PhraseSequence<any>> = {
   type: "nestedPhrase";
@@ -194,13 +246,16 @@ export type NestedPhrase<T extends PhraseSequence<any>> = {
 };
 
 // Type helpers for joining phrase parts
-type JoinPhrasePartsValue<Parts extends readonly PhrasePart[]> =
+type JoinPhrasePartsValue<
+  Parts extends readonly PhrasePart[],
+  Acc extends string = ""
+> =
   Parts extends readonly [
     infer First extends PhrasePart,
-    ...infer Rest extends PhrasePart[]
+    ...infer Rest extends readonly PhrasePart[]
   ]
-    ? `${First["value"]}${JoinPhrasePartsValue<Rest>}`
-    : "";
+    ? JoinPhrasePartsValue<Rest, `${Acc}${First["value"]}`>
+    : Acc;
 
 // Define the pattern type for why-intensifier with emphasis particle
 export type WhyIntensifierPatternWithEmphasis<
@@ -225,3 +280,5 @@ type いいよ = PhraseWithParticle<ConjugateAdjective<いい, "Basic">, "よ">;
 type 来る = IrregularVerb & { dictionary: "来る" };
 type 来いよ = PhraseWithParticle<ConjugateVerb<来る, "Imperative">, "よ">;
 type いいよ来いよ = ConnectedPhrases<いいよ, 来いよ>;
+type 勉強する = SuruVerb<"勉強">;
+type 勉強した = Sentence<[VerbPart<勉強する, "Ta">]>;

--- a/src/verb-types.d.ts
+++ b/src/verb-types.d.ts
@@ -16,7 +16,12 @@ export type IrregularVerb = {
   dictionary: "する" | "来る" | "くる";
 };
 
-export type Verb = GodanVerb | IchidanVerb | IrregularVerb;
+export type SuruVerb<Noun extends string = string> = {
+  type: "suru-verb";
+  noun: Noun;
+};
+
+export type Verb = GodanVerb | IchidanVerb | IrregularVerb | SuruVerb;
 
 // Conjugation forms
 export type ConjugationForm =
@@ -248,14 +253,20 @@ export type ConjugateVerb<
     : never
   : V extends IrregularVerb
   ? GetIrregularConjugation<V, F>
+  : V extends SuruVerb
+  ? F extends "Dictionary"
+    ? `${V["noun"]}する`
+    : `${V["noun"]}${GetIrregularConjugation<{ type: "irregular"; dictionary: "する" }, F>}`
   : never;
 
 // Example usage (we keep this for documentation)
 type 話す = GodanVerb & { stem: "話"; ending: "す" };
 type 食べる = IchidanVerb & { stem: "食べ"; ending: "る" };
 type する = IrregularVerb & { dictionary: "する" };
+type 勉強する = SuruVerb<"勉強">;
 
 // Type-level conjugation tests
 type 話すMasu = ConjugateVerb<話す, "Masu">; // Evaluates to "話し"
 type 食べるTe = ConjugateVerb<食べる, "Te">; // Evaluates to "食べて"
+type 勉強した = ConjugateVerb<勉強する, "Ta">; // Evaluates to "勉強した"
 type するImperative = ConjugateVerb<する, "Imperative">; // Evaluates to "しろ"


### PR DESCRIPTION
## What

Adds `bun run annotate "<日本語>"` — a local workflow that turns a Japanese sentence into a **verified** Typed Japanese snippet and installs it into the Playground gallery.

The pipeline is the project's *"the type checker grades the LLM"* thesis as a tool:

1. Prompt an LLM (`codex exec` by default, `--engine claude` optional) with a cheatsheet of the library API; it returns JSON `{code, en, title}`.
2. **Verify** in-memory with the TypeScript Compiler API: the snippet must type-check against the real `src/` library **and** its last `type` alias must resolve to exactly the input string.
3. A **structural audit** forces every particle / punctuation mark / technical term into its own typed part, rejecting `NounPhrase` / template-literal shortcuts that hide structure.
4. On failure, the diagnostics are fed back to the model and it retries (`--retries`, default 3). Only a verified snippet is installed.

Verified snippets append to `examples.generated.json` and show in a new **✨ Generated** group in the Playground; `verify:snippets` now covers them too.

## Library changes

- `Sentence<[...Part[]]>` as the preferred flat, auditable sentence shape.
- `SuruVerb<Noun>` for 名詞+する compounds (reuses the する conjugation map).
- Expanded `Particle` / `PunctuationMark` unions; new `TechnicalTermPart` / `WhitespacePart` / `SuffixPart`.
- `JoinPhrasePartsValue` rewritten **tail-recursively** so long sentences don't exceed TS instantiation depth.

## Audit precision fix

The buried-particle heuristic over-rejected conventionally-kana 形式名詞 that merely *contain* a particle homograph (`こと`→と, `もの`→の, `からだ`→から, `はず`→は). Added a documented `KANA_LEXEME_EXCEPTIONS` set so these single lexemes pass, while genuine buried particles (`会社に`, `これは`) and bare particles (`の`) are still rejected. `structuralAudit`/`verify` are now importable (`import.meta.main` guard) for testing.

Also: fixed drifted curated `SNIPPETS` to the English form names the library now uses (`"て形"`→`"Te"` etc.).

## Verification

- `pnpm typecheck` ✓ (src + app)
- `pnpm verify:snippets` ✓ — 384 snippets across 47 chapters + generated, all type-check and resolve
- Audit unit test ✓ — formal nouns accepted, `会社に` / `これは` / bare `の` rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)