### PR TITLE
Eval view in the playground + fix structure diagram not rendering

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -3,6 +3,7 @@ import Concepts from "./components/Concepts";
 import Tutorial from "./components/Tutorial";
 import Playground from "./components/Playground";
 import Glossary from "./components/Glossary";
+import Eval from "./components/Eval";
 import { useLang } from "./context/lang";
 import { useTheme } from "./context/theme";
 import { useRoute } from "./context/route";
@@ -135,6 +136,12 @@ export default function App() {
         >
           {t("Playground", "演练场")}
         </button>
+        <button
+          className={`${TAB_BASE} ${tabState(tab === "eval")}`}
+          onClick={() => navigate({ tab: "eval" })}
+        >
+          {t("Eval", "评测")}
+        </button>
       </nav>
 
       <main className="flex-1 pt-1.5 pb-4">
@@ -142,6 +149,7 @@ export default function App() {
         {tab === "tutorial" && <Tutorial />}
         {tab === "glossary" && <Glossary />}
         {tab === "playground" && <Playground />}
+        {tab === "eval" && <Eval />}
       </main>
 
       <footer className="px-1 pt-[18px] pb-[26px] text-center text-[0.78rem] text-ink-300">

--- a/playground/src/components/Analyzer.tsx
+++ b/playground/src/components/Analyzer.tsx
@@ -121,16 +121,29 @@ export default function Analyzer({ code, gloss }: Props) {
       return;
     }
 
-    const built = await buildTree(src, alias);
+    let built: CompositionNode | null = null;
+    try {
+      built = await buildTree(src, alias);
+    } catch {
+      built = null;
+    }
     if (token !== tokenRef.current) return;
     if (!built) {
       setTree(null);
       return;
     }
-    const texts = Array.from(collectTexts(built));
-    const map = await resolveValues(monaco, src, texts);
-    if (token !== tokenRef.current) return;
-    setTree(applyResolved(built, map));
+    // Show the structure immediately. Value resolution runs through Monaco's TS
+    // worker, which can lag or throw (especially on first load); it must never
+    // blank the diagram — it only enriches each node with its resolved string.
+    setTree(built);
+    try {
+      const texts = Array.from(collectTexts(built));
+      const map = await resolveValues(monaco, src, texts);
+      if (token !== tokenRef.current) return;
+      setTree(applyResolved(built, map));
+    } catch {
+      /* keep the unresolved structure on screen */
+    }
   }, []);
 
   const scheduleAnalysis = useCallback(() => {

--- a/playground/src/components/Eval.tsx
+++ b/playground/src/components/Eval.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from "react";
+import { useLang } from "../context/lang";
+
+/**
+ * Eval view — renders the committed parsing-accuracy benchmark results as-is.
+ *
+ * Data source: playground/eval/history/bench-*.json, imported eagerly via
+ * import.meta.glob. Each future round commits a new bench-NNN.json (+ updates
+ * benchmark-scoreboard.md); once that PR merges and the playground redeploys,
+ * the new round appears here automatically — no code change needed.
+ */
+interface PerItem {
+  id: string;
+  source: string;
+  chapter: string | null;
+  jp: string;
+  total: number;
+  verdict: "conforms" | "needs-work";
+  issueCount: number;
+}
+interface Proposal {
+  target: "ts-def" | "prompt" | "content";
+  title: string;
+  confidence?: string;
+}
+interface RoundResult {
+  round: number;
+  sampled: number;
+  scored: number;
+  roundScore: number;
+  byDimension: Record<string, number>;
+  perItem: PerItem[];
+  proposals: Proposal[];
+}
+
+const modules = import.meta.glob<RoundResult>("../../eval/history/bench-*.json", {
+  eager: true,
+  import: "default",
+});
+const ROUNDS: RoundResult[] = Object.values(modules).sort(
+  (a, b) => a.round - b.round
+);
+
+// The six rubric dimensions, in order, with short bilingual labels.
+const DIMS: { key: string; en: string; zh: string }[] = [
+  { key: "D1", en: "POS", zh: "词类" },
+  { key: "D2", en: "Decomp", zh: "分解" },
+  { key: "D3", en: "Particle", zh: "助词" },
+  { key: "D4", en: "Conjug.", zh: "活用" },
+  { key: "D5", en: "Resolve", zh: "还原" },
+  { key: "D6", en: "Idiom", zh: "地道" },
+];
+
+const REPO = "https://github.com/typedgrammar/typed-japanese/tree/main/playground/eval";
+const pct = (x: number | undefined) =>
+  x == null ? "—" : `${(x * 100).toFixed(1)}%`;
+
+function ConformanceBar({ value }: { value: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 rounded-full bg-surface-2 overflow-hidden min-w-[60px]">
+        <div
+          className="h-full bg-sakura-500 rounded-full"
+          style={{ width: `${Math.round(value * 100)}%` }}
+        />
+      </div>
+      <span className="tabular-nums text-ink-700 font-semibold w-[52px] text-right">
+        {pct(value)}
+      </span>
+    </div>
+  );
+}
+
+export default function Eval() {
+  const { lang, t } = useLang();
+  const first = ROUNDS.length ? ROUNDS[0] : undefined;
+  const last = ROUNDS.length ? ROUNDS[ROUNDS.length - 1] : undefined;
+  const [open, setOpen] = useState<number>(last?.round ?? 0);
+  const delta = useMemo(
+    () => (first && last ? last.roundScore - first.roundScore : 0),
+    [first, last]
+  );
+
+  if (!ROUNDS.length) {
+    return (
+      <p className="text-ink-500">
+        {t("No eval rounds recorded yet.", "暂无评测轮次记录。")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-w-[920px]">
+      <div className="mb-6">
+        <h2 className="m-0 font-heading text-[1.5rem] font-extrabold text-ink-900">
+          {t("Parsing accuracy eval", "解析准确度评测")}
+        </h2>
+        <p className="mt-2 mb-0 text-[0.92rem] text-ink-500 leading-relaxed max-w-[68ch]">
+          {t(
+            "A fixed benchmark of grammar examples, scored each round by independent reviewers against a rubric across six dimensions. Conformance is the mean item score (out of 12). The same items are scored every round, so the trend is comparable. Results are shown as recorded.",
+            "一组固定的语法示例基准，每轮由独立评审依据评分标准、从六个维度打分。Conformance 为各条目得分的均值（满分 12）。每轮评测的都是同一批条目，因此趋势可比。此处如实展示记录结果。"
+          )}
+        </p>
+        <a
+          className="inline-block mt-2 text-[0.85rem] font-semibold text-sakura-600 no-underline hover:underline"
+          href={REPO}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {t("Rubric & methodology", "评分标准与方法")} →
+        </a>
+      </div>
+
+      {/* Trend overview */}
+      <div className="rounded-2xl border border-border bg-surface overflow-hidden mb-7">
+        <div className="flex items-baseline justify-between px-5 py-3 border-b border-border">
+          <h3 className="m-0 text-[1rem] font-bold text-ink-900">
+            {t("Trend", "趋势")}
+          </h3>
+          <span className="text-[0.82rem] text-ink-400">
+            {t(
+              `${ROUNDS.length} rounds · ${delta >= 0 ? "+" : ""}${(delta * 100).toFixed(1)} pts overall`,
+              `${ROUNDS.length} 轮 · 累计 ${delta >= 0 ? "+" : ""}${(delta * 100).toFixed(1)} 分`
+            )}
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-[0.86rem]">
+            <thead>
+              <tr className="text-ink-400 text-left">
+                <th className="font-semibold px-5 py-2.5">{t("Round", "轮次")}</th>
+                <th className="font-semibold px-3 py-2.5 min-w-[160px]">
+                  {t("Conformance", "符合度")}
+                </th>
+                {DIMS.map((d) => (
+                  <th key={d.key} className="font-semibold px-3 py-2.5 text-right whitespace-nowrap">
+                    <span title={d.key}>{lang === "zh" ? d.zh : d.en}</span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROUNDS.map((r) => (
+                <tr
+                  key={r.round}
+                  className={`border-t border-border ${r.round === open ? "bg-surface-2" : ""}`}
+                >
+                  <td className="px-5 py-2.5 font-semibold text-ink-700 tabular-nums">
+                    {String(r.round).padStart(3, "0")}
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <ConformanceBar value={r.roundScore} />
+                  </td>
+                  {DIMS.map((d) => (
+                    <td
+                      key={d.key}
+                      className="px-3 py-2.5 text-right tabular-nums text-ink-500 whitespace-nowrap"
+                    >
+                      {pct(r.byDimension?.[d.key])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Per-round detail */}
+      <h3 className="m-0 mb-3 text-[1rem] font-bold text-ink-900">
+        {t("Rounds", "各轮明细")}
+      </h3>
+      <div className="flex flex-col gap-3">
+        {[...ROUNDS].reverse().map((r) => {
+          const isOpen = r.round === open;
+          return (
+            <div
+              key={r.round}
+              className="rounded-2xl border border-border bg-surface overflow-hidden"
+            >
+              <button
+                className="w-full flex items-center justify-between gap-4 px-5 py-3.5 cursor-pointer text-left bg-transparent border-0"
+                onClick={() => setOpen(isOpen ? -1 : r.round)}
+                aria-expanded={isOpen}
+              >
+                <span className="flex items-baseline gap-3">
+                  <span className="font-bold text-ink-900">
+                    {t("Round", "第")} {String(r.round).padStart(3, "0")}
+                  </span>
+                  <span className="text-[0.85rem] text-ink-400">
+                    {r.scored}/{r.sampled} {t("items", "条")}
+                  </span>
+                </span>
+                <span className="flex items-center gap-3">
+                  <span className="tabular-nums font-semibold text-sakura-600">
+                    {pct(r.roundScore)}
+                  </span>
+                  <svg
+                    width="14" height="14" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className={`text-ink-300 transition-transform duration-150 ${isOpen ? "rotate-180" : ""}`}
+                    aria-hidden="true"
+                  >
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </span>
+              </button>
+
+              {isOpen && (
+                <div className="px-5 pb-4 border-t border-border">
+                  <table className="w-full border-collapse text-[0.86rem] mt-1">
+                    <thead>
+                      <tr className="text-ink-400 text-left">
+                        <th className="font-semibold py-2 pr-3">{t("Sentence", "句子")}</th>
+                        <th className="font-semibold py-2 px-3 whitespace-nowrap">{t("Source", "来源")}</th>
+                        <th className="font-semibold py-2 px-3 text-right whitespace-nowrap">{t("Score", "得分")}</th>
+                        <th className="font-semibold py-2 pl-3 text-right whitespace-nowrap">{t("Verdict", "判定")}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {r.perItem.map((it) => (
+                        <tr key={it.id} className="border-t border-border">
+                          <td className="py-2 pr-3 font-jp text-ink-900">{it.jp}</td>
+                          <td className="py-2 px-3 text-ink-400 whitespace-nowrap">
+                            {it.chapter ?? it.source}
+                          </td>
+                          <td className="py-2 px-3 text-right tabular-nums text-ink-700">
+                            {it.total}/12
+                          </td>
+                          <td className="py-2 pl-3 text-right whitespace-nowrap">
+                            <span
+                              className={
+                                it.verdict === "conforms"
+                                  ? "text-[0.78rem] font-semibold text-emerald-600"
+                                  : "text-[0.78rem] font-semibold text-amber-600"
+                              }
+                            >
+                              {it.verdict === "conforms"
+                                ? t("conforms", "符合")
+                                : t("needs work", "待改进")}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+
+                  {r.proposals?.length > 0 && (
+                    <div className="mt-4">
+                      <div className="text-[0.8rem] font-semibold text-ink-400 mb-1.5">
+                        {t("Fix proposals from this round", "本轮提出的改进建议")}
+                      </div>
+                      <ul className="m-0 pl-0 list-none flex flex-col gap-1.5">
+                        {r.proposals.map((p, i) => (
+                          <li key={i} className="flex items-start gap-2 text-[0.85rem]">
+                            <span className="mt-[2px] flex-none text-[0.7rem] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-surface-2 text-ink-500">
+                              {p.target}
+                            </span>
+                            <span className="text-ink-700">{p.title}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/playground/src/context/route.tsx
+++ b/playground/src/context/route.tsx
@@ -22,7 +22,7 @@ import {
   type ReactNode,
 } from "react";
 
-export type Tab = "concepts" | "tutorial" | "glossary" | "playground";
+export type Tab = "concepts" | "tutorial" | "glossary" | "playground" | "eval";
 export type Lang = "en" | "zh";
 
 export interface Route {
@@ -52,12 +52,14 @@ const TAB_TO_SEG: Record<Tab, string> = {
   tutorial: "course",
   glossary: "glossary",
   playground: "playground",
+  eval: "eval",
 };
 const SEG_TO_TAB: Record<string, Tab> = {
   foundations: "concepts",
   course: "tutorial",
   glossary: "glossary",
   playground: "playground",
+  eval: "eval",
 };
 
 export const LANGS: Lang[] = ["en", "zh"];

--- a/playground/src/entry-server.tsx
+++ b/playground/src/entry-server.tsx
@@ -136,6 +136,15 @@ export function getRoutes(): RouteMeta[] {
     },
     "WebApplication"
   );
+  make(
+    { tab: "eval" },
+    { en: "Parsing Eval", zh: "解析评测" },
+    {
+      en: "A fixed benchmark of grammar examples scored each round by independent reviewers against a six-dimension rubric — the project's quantifiable, comparable parsing-accuracy metric over time.",
+      zh: "一组固定的语法示例基准，每轮由独立评审依据六维评分标准打分 —— 项目随时间可量化、可比较的解析准确度指标。",
+    },
+    "Dataset"
+  );
 
   // Course chapters
   for (const c of CHAPTERS) {

--- a/playground/src/tutorial/reverseIndex.generated.ts
+++ b/playground/src/tutorial/reverseIndex.generated.ts
@@ -220,6 +220,15 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "jp": "コーヒーよりお茶のほうがいいです"
     },
     {
+      "chapterId": "e17",
+      "chapterTitleEn": "Obligation",
+      "chapterTitleZh": "义务",
+      "pointTitleEn": "〜なくてもいい — “don't have to / need not”",
+      "pointTitleZh": "〜なくてもいい ——「不必/可以不」",
+      "anchor": "ex-e17-e17-2-0",
+      "jp": "今日は来なくてもいいです"
+    },
+    {
       "chapterId": "e20",
       "chapterTitleEn": "Quotation & なら",
       "chapterTitleZh": "引用与なら",
@@ -236,6 +245,17 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "pointTitleZh": "〜ば〜ほど ——「越……越……」",
       "anchor": "ex-i06-i06-3-1",
       "jp": "高ければ高いほどいい"
+    }
+  ],
+  "いく": [
+    {
+      "chapterId": "a03",
+      "chapterTitleEn": "The 〜わけ family",
+      "chapterTitleZh": "〜わけ系列",
+      "pointTitleEn": "〜わけにはいかない — “I can't very well…”",
+      "pointTitleZh": "〜わけにはいかない ——「不能、不可以」",
+      "anchor": "ex-a03-a03-3-2",
+      "jp": "今日は休むわけにはいきません"
     }
   ],
   "いたす": [
@@ -450,6 +470,15 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
     }
   ],
   "かける": [
+    {
+      "chapterId": "a12",
+      "chapterTitleEn": "Written & literary style",
+      "chapterTitleZh": "书面语与文语",
+      "pointTitleEn": "〜ぬ — the classical negative",
+      "pointTitleZh": "〜ぬ —— 文语否定",
+      "anchor": "ex-a12-a12-3-1",
+      "jp": "知らぬ人に声をかけられた"
+    },
     {
       "chapterId": "i15",
       "chapterTitleEn": "Nominalization の・こと, 〜とき",
@@ -1091,6 +1120,15 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "jp": "子供は毎日勉強させられる"
     },
     {
+      "chapterId": "i05",
+      "chapterTitleEn": "Humble & polite 謙譲語・丁寧語",
+      "chapterTitleZh": "谦让语与郑重语",
+      "pointTitleEn": "お〜する — the humble pattern",
+      "pointTitleZh": "お〜する ——谦让句型",
+      "anchor": "ex-i05-i05-1-2",
+      "jp": "ここでお待ちします"
+    },
+    {
       "chapterId": "i06",
       "chapterTitleEn": "The 〜ば conditional & 〜ば〜ほど",
       "chapterTitleZh": "〜ば条件与〜ば〜ほど",
@@ -1500,6 +1538,17 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "pointTitleZh": "〜わけではない ——「并不是说……、未必」",
       "anchor": "ex-a03-a03-2-1",
       "jp": "全部わかるわけではない"
+    }
+  ],
+  "わけ": [
+    {
+      "chapterId": "a03",
+      "chapterTitleEn": "The 〜わけ family",
+      "chapterTitleZh": "〜わけ系列",
+      "pointTitleEn": "〜わけにはいかない — “I can't very well…”",
+      "pointTitleZh": "〜わけにはいかない ——「不能、不可以」",
+      "anchor": "ex-a03-a03-3-2",
+      "jp": "今日は休むわけにはいきません"
     }
   ],
   "わさび": [
@@ -6066,6 +6115,17 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "jp": "素晴らしいことだ"
     }
   ],
+  "早い": [
+    {
+      "chapterId": "i08",
+      "chapterTitleEn": "〜ように / 〜ような",
+      "chapterTitleZh": "〜ように／〜ような",
+      "pointTitleEn": "〜ようにする — “make an effort to / try to (habitually)”",
+      "pointTitleZh": "〜ようにする ——「(尽量)做到……、努力养成……」",
+      "anchor": "ex-i08-i08-3-2",
+      "jp": "早く寝るようにしてください"
+    }
+  ],
   "早く": [
     {
       "chapterId": "a02",
@@ -6093,15 +6153,6 @@ export const REVERSE_INDEX: Record<string, ExampleRef[]> = {
       "pointTitleZh": "〜なければならない ——「必须/不得不」",
       "anchor": "ex-e17-e17-1-1",
       "jp": "明日早く起きなければなりません"
-    },
-    {
-      "chapterId": "i08",
-      "chapterTitleEn": "〜ように / 〜ような",
-      "chapterTitleZh": "〜ように／〜ような",
-      "pointTitleEn": "〜ようにする — “make an effort to / try to (habitually)”",
-      "pointTitleZh": "〜ようにする ——「(尽量)做到……、努力养成……」",
-      "anchor": "ex-i08-i08-3-2",
-      "jp": "早く寝るようにしてください"
     }
   ],
   "窓": [


### PR DESCRIPTION
## Eval view (new tab)

Adds an **Eval** tab beside Playground that renders the parsing-accuracy benchmark
results, faithfully and with minimal processing:

- **Trend** — each round's overall conformance plus the six rubric dimensions
  (POS / decomposition / particle / conjugation / resolution / idiom), on the
  *fixed* benchmark so rounds are comparable.
- **Per round** — each sentence with its score (/12) and verdict, and the fix
  proposals that round produced.

Data comes from the committed `playground/eval/history/bench-*.json` via
`import.meta.glob`, so **every future round that merges shows up here
automatically** on the next deploy — no code change required. Route + prerender
metadata wired for EN and ZH.

## Fix: structure diagram not rendering

In the course's structure-analysis panel the composition tree sometimes stayed
empty (showing the "Define a `type` alias…" placeholder) even though the snippet
type-checked — reproducible on `私は学生です`. Cause: `setTree()` ran only *after*
`resolveValues()` (a Monaco-worker call with no error handling), so a worker
lag/throw on load left the diagram blank despite `buildTree()` having succeeded.

Now the structure renders as soon as `buildTree()` returns; value resolution is a
best-effort enrichment wrapped in try/catch that can never blank the diagram.
(Confirmed `buildTree` produces the correct tree for this snippet via the node
bridge; the change is strictly safer — it can only add the render, never remove
it.)

Build: `npm run build` green (prerendered 106 pages incl. /en/eval, /zh/eval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)