### PR TITLE
Fix structure-tree shredding unmodeled words (もらう → も + らう) + model もらう as a verb

### DIFF
--- a/playground/src/analysis/parse.ts
+++ b/playground/src/analysis/parse.ts
@@ -222,27 +222,50 @@ function tokenizeLiteral(text: string): Tok[] {
       i = j;
       continue;
     }
-    // Kana / other: longest vocabulary match (particles, suffixes, kana words).
+    // Kana run: take it atomically and try to tokenize the WHOLE run into known
+    // vocabulary (longest-match). Only emit the split if it consumes the entire
+    // run with no leftover — otherwise keep the run as one literal. This stops a
+    // greedy particle match from shredding an unmodeled word (もらう → も + らう);
+    // a verb left as a raw literal stays whole rather than splitting wrongly.
+    let j = i;
+    while (j < text.length && !KANJI.test(text[j]!)) j++;
+    const run = text.slice(i, j);
+    const toks = tokenizeKanaRun(run);
+    if (toks) {
+      flush();
+      for (const tk of toks) out.push(tk);
+    } else {
+      plain += run;
+    }
+    i = j;
+  }
+  flush();
+  return out;
+}
+
+/**
+ * Greedily longest-match a contiguous kana run against the vocabulary. Returns
+ * the token list only if the run is FULLY covered by known surfaces; returns
+ * null (caller keeps the run as a single literal) the moment any character can't
+ * be matched, so unknown words are never partially shredded.
+ */
+function tokenizeKanaRun(run: string): Tok[] | null {
+  const toks: Tok[] = [];
+  for (let i = 0; i < run.length; ) {
     let matched: string | null = null;
-    const maxL = Math.min(SURFACE_MAXLEN, text.length - i);
+    const maxL = Math.min(SURFACE_MAXLEN, run.length - i);
     for (let len = maxL; len >= 1; len--) {
-      const sub = text.slice(i, i + len);
-      if (SURFACES.has(sub) && !KANJI.test(sub[0]!)) {
+      const sub = run.slice(i, i + len);
+      if (SURFACES.has(sub)) {
         matched = sub;
         break;
       }
     }
-    if (matched) {
-      flush();
-      out.push({ surface: matched, category: categorizeSurface(matched) });
-      i += matched.length;
-    } else {
-      plain += text[i];
-      i += 1;
-    }
+    if (!matched) return null; // unknown remainder → keep the whole run as one literal
+    toks.push({ surface: matched, category: categorizeSurface(matched) });
+    i += matched.length;
   }
-  flush();
-  return out;
+  return toks;
 }
 
 function literalNodes(

--- a/playground/src/tutorial/chapters/i13.ts
+++ b/playground/src/tutorial/chapters/i13.ts
@@ -105,14 +105,15 @@ type 先生が私に辞書をくれました = \`\${PhraseWithParticle<先生, "
           reading: "わたしはともだちにほんをもらう",
           en: "I receive a book from my friend.",
           zh: "我从朋友那里得到一本书。",
-          code: `import type { CommonNoun, Pronoun, PhraseWithParticle } from "typed-japanese";
+          code: `import type { CommonNoun, Pronoun, PhraseWithParticle, GodanVerb, ConjugateVerb } from "typed-japanese";
 
 type 私 = Pronoun<"私">;
 type 友達 = CommonNoun<"友達">;
 type 本 = CommonNoun<"本">;
+type もらう = GodanVerb & { stem: "もら"; ending: "う" };
 
-// 私 は + 友達 に (source) + 本 を + もらう
-type 私は友達に本をもらう = \`\${PhraseWithParticle<私, "は">}\${PhraseWithParticle<友達, "に">}\${PhraseWithParticle<本, "を">}もらう\`;
+// 私 は + 友達 に (source) + 本 を + もらう (辞書形)
+type 私は友達に本をもらう = \`\${PhraseWithParticle<私, "は">}\${PhraseWithParticle<友達, "に">}\${PhraseWithParticle<本, "を">}\${ConjugateVerb<もらう, "Dictionary">}\`;
 `,
         },
         {
@@ -120,14 +121,15 @@ type 私は友達に本をもらう = \`\${PhraseWithParticle<私, "は">}\${Phr
           reading: "わたしはははにおかねをもらいました",
           en: "I received money from my mother.",
           zh: "我从母亲那里收到了钱。",
-          code: `import type { CommonNoun, Pronoun, PhraseWithParticle } from "typed-japanese";
+          code: `import type { CommonNoun, Pronoun, PhraseWithParticle, GodanVerb, ConjugateVerb } from "typed-japanese";
 
 type 私 = Pronoun<"私">;
 type 母 = CommonNoun<"母">;
 type お金 = CommonNoun<"お金">;
+type もらう = GodanVerb & { stem: "もら"; ending: "う" };
 
-// 私 は + 母 に + お金 を + もらいました (polite past)
-type 私は母にお金をもらいました = \`\${PhraseWithParticle<私, "は">}\${PhraseWithParticle<母, "に">}\${PhraseWithParticle<お金, "を">}もらいました\`;
+// 私 は + 母 に + お金 を + もらいました (もらう の丁寧過去)
+type 私は母にお金をもらいました = \`\${PhraseWithParticle<私, "は">}\${PhraseWithParticle<母, "に">}\${PhraseWithParticle<お金, "を">}\${ConjugateVerb<もらう, "MasuPast">}\`;
 `,
         },
       ],

--- a/playground/src/vocab/entries/extra-03.ts
+++ b/playground/src/vocab/entries/extra-03.ts
@@ -18,6 +18,7 @@ const entries: VocabEntry[] = [
   { word: "わけ", reading: "わけ", romaji: "wake", pos: "noun", en: "reason; (in 〜わけにはいかない) way/grounds", zh: "道理；缘由" },
   { word: "いく", reading: "いく", romaji: "iku", pos: "verb-godan", en: "to go", zh: "去" },
   { word: "早い", reading: "はやい", romaji: "hayai", pos: "i-adjective", en: "early; fast", zh: "早；快" },
+  { word: "もらう", reading: "もらう", romaji: "morau", pos: "verb-godan", en: "to receive, to get", zh: "得到；收到" },
 ];
 
 export default entries;


### PR DESCRIPTION
## The bug

In the course's structure-analysis panel, `もらう` in 私は友達に本をもらう rendered as
助詞「も」 + リテラル「らう」 — the verb was shredded.

Cause: `tokenizeLiteral` walked the vocabulary one position at a time and kept any
unmatched kana as a bare literal, so a word left as a raw template literal split
wherever a particle happened to begin it. An audit across all chapters found
**152 chunks** mis-split this way — essentially every advanced-grammar tail:
にすぎない, にちがいない, ばかりか, どころか, のみならず, ずにはいられない, つもりです,
ように, より, らしいです, みたいです, いただけますか, おっしゃいました, …

## Fix

- **Parser (fixes all 152):** tokenize a contiguous kana run atomically — emit
  the split only if the run is *fully* covered by known vocabulary, otherwise
  keep it whole (mirroring the existing kanji-run rule). Clean multi-particle
  glue (には, ます+が) still splits; unknown words/fixed expressions stay whole
  instead of being shredded. Display-only — type resolution is unchanged.
- **Content:** `もらう` is a real godan verb, so model it via `ConjugateVerb`
  (Dictionary / MasuPast) in the two 授受 examples rather than a raw literal;
  added もらう to the dictionary.

Gate: snippets ✓ vocab ✓ typecheck ✓ lib ✓ annotate ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)